### PR TITLE
Use `ExprReference` to decompose reductions

### DIFF
--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -86,7 +86,7 @@ class Expr:
                     if param:
                         header += f" {param}={repr(op)}"
                     else:
-                        header += repr(op)
+                        header += f" {repr(op)}"
         lines = [header] + lines
         lines = [" " * indent + line for line in lines]
 

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -62,8 +62,7 @@ def df_bc(fn):
 )
 def test_optimize(tmpdir, input, expected):
     fn = _make_file(tmpdir, format="parquet")
-    result = optimize(input(fn), fuse=False)
-    assert str(result.expr) == str(expected(fn).expr)
+    assert str(input(fn).simplify().expr) == str(expected(fn).simplify().expr)
 
 
 @pytest.mark.parametrize("fmt", ["parquet", "csv"])

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -321,11 +321,12 @@ def test_tree_repr(df, fuse):
     assert "1" in s
     assert "True" not in s
     assert "None" not in s
-    assert "skipna=False" in s
     assert str(df.seed) in s.lower()
     if fuse:
         assert "Fused" in s
-        assert s.count("|") == 9
+        assert "|" in s
+    else:
+        assert "skipna=False" in s
 
 
 def test_simple_graphs(df):


### PR DESCRIPTION
Possible alternative to #65

Uses a new/simple `ExprReference` mechanism to split `ApplyConcatApply` into distinct `Count` and `TreeReduce` expressions at `simplify` time. This approach does not require any changes to how `Reductions` (like sum/min/max) need to be implemented.