### PR TITLE
Implement ``_simplify_up`` for ``assign``

### DIFF
--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -1015,6 +1015,14 @@ class Assign(Elemwise):
     def _node_label_args(self):
         return [self.frame, self.key, self.value]
 
+    def _simplify_up(self, parent):
+        if isinstance(parent, Projection):
+            if self.key not in parent.columns:
+                return self.frame[parent.columns]
+
+            columns = list(set(parent.columns) - {self.key})
+            return type(self)(self.frame[columns], *self.operands[1:])
+
 
 class Filter(Blockwise):
     _parameters = ["frame", "predicate"]

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -1104,12 +1104,7 @@ class Assign(Elemwise):
 
     def _simplify_up(self, parent):
         if isinstance(parent, Projection):
-            columns = (
-                parent.columns
-                if isinstance(parent.columns, pd.Index)
-                else [parent.columns]
-            )
-            columns = set(columns) - {self.key}
+            columns = set(parent.columns) - {self.key}
             if columns == set(self.frame.columns):
                 # Protect against pushing the same projection twice
                 return

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -1104,6 +1104,9 @@ class Assign(Elemwise):
 
     def _simplify_up(self, parent):
         if isinstance(parent, Projection):
+            if self.key not in parent.columns:
+                return type(parent)(self.frame, *parent.operands[1:])
+
             columns = set(parent.columns) - {self.key}
             if columns == set(self.frame.columns):
                 # Protect against pushing the same projection twice

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -780,6 +780,15 @@ def test_assign_simplify(pdf):
     assert result._name == expected._name
 
 
+def test_assign_simplify_new_column_not_needed(pdf):
+    df = from_pandas(pdf)
+    df2 = from_pandas(pdf)
+    df["new"] = df.x > 1
+    result = optimize(df[["x"]], fuse=False)
+    expected = optimize(df2[["x"]], fuse=False)
+    assert result._name == expected._name
+
+
 def test_assign_simplify_series(pdf):
     df = from_pandas(pdf)
     df2 = from_pandas(pdf)

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -775,18 +775,24 @@ def test_assign_simplify(pdf):
     df = from_pandas(pdf)
     df2 = from_pandas(pdf)
     df["new"] = df.x > 1
-    result = optimize(df[["x", "new"]], fuse=False)
-    expected = optimize(df2[["x"]].assign(new=df2.x > 1), fuse=False)
+    result = df[["x", "new"]].simplify()
+    expected = df2[["x"]].assign(new=df2.x > 1).simplify()
     assert result._name == expected._name
+
+    pdf["new"] = pdf.x > 1
+    assert_eq(pdf[["x", "new"]], result)
 
 
 def test_assign_simplify_new_column_not_needed(pdf):
     df = from_pandas(pdf)
     df2 = from_pandas(pdf)
     df["new"] = df.x > 1
-    result = optimize(df[["x"]], fuse=False)
-    expected = optimize(df2[["x"]], fuse=False)
+    result = df[["x"]].simplify()
+    expected = df2[["x"]].simplify()
     assert result._name == expected._name
+
+    pdf["new"] = pdf.x > 1
+    assert_eq(result, pdf[["x"]])
 
 
 def test_assign_simplify_series(pdf):

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -681,3 +681,21 @@ def test_sample(df):
     result = df.sample(frac=0.5, random_state=1234)
     expected = df.sample(frac=0.5, random_state=1234)
     assert_eq(result, expected)
+
+
+def test_assign_simplify_key_not_used(pdf):
+    df = from_pandas(pdf)
+    df2 = from_pandas(pdf)
+    df["new"] = df.x > 1
+    result = optimize(df.x)
+    expected = optimize(df2.x)
+    assert result._name == expected._name
+
+
+def test_assign_simplify(pdf):
+    df = from_pandas(pdf)
+    df2 = from_pandas(pdf)
+    df["new"] = df.x > 1
+    result = optimize(df[["x", "new"]])
+    expected = optimize(df2[["x"]].assign(new=df.x > 1))
+    assert result._name == expected._name

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -683,19 +683,19 @@ def test_sample(df):
     assert_eq(result, expected)
 
 
-def test_assign_simplify_key_not_used(pdf):
-    df = from_pandas(pdf)
-    df2 = from_pandas(pdf)
-    df["new"] = df.x > 1
-    result = optimize(df.x)
-    expected = optimize(df2.x)
-    assert result._name == expected._name
-
-
 def test_assign_simplify(pdf):
     df = from_pandas(pdf)
     df2 = from_pandas(pdf)
     df["new"] = df.x > 1
-    result = optimize(df[["x", "new"]])
-    expected = optimize(df2[["x"]].assign(new=df.x > 1))
+    result = optimize(df[["x", "new"]], fuse=False)
+    expected = optimize(df2[["x"]].assign(new=df2.x > 1), fuse=False)
+    assert result._name == expected._name
+
+
+def test_assign_simplify_series(pdf):
+    df = from_pandas(pdf)
+    df2 = from_pandas(pdf)
+    df["new"] = df.x > 1
+    result = optimize(df.new, fuse=False)
+    expected = optimize(df2[[]].assign(new=df2.x > 1).new, fuse=False)
     assert result._name == expected._name

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -415,7 +415,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -415,7 +415,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Ran into this with the taxi dataset. Something like:

```
df = read_parquet(...)
df["tipped"] = df.tips > 0
df.groupby(....).agg({"tipped": "mean", "base_passenger_fare": "sum"})
```

doesn't push the projection through, which hinders us when demoing somewhere (my assumption)
