### PR TITLE
Change columns of Projection to return an Index

### DIFF
--- a/dask_expr/datasets.py
+++ b/dask_expr/datasets.py
@@ -72,10 +72,7 @@ class Timeseries(PartitionsFiltered, BlockwiseIO):
 
     def _simplify_up(self, parent):
         if isinstance(parent, Projection) and len(self.dtypes) > 1:
-            if isinstance(parent.columns, (list, pd.Index)):
-                dtypes = {col: self.operand("dtypes")[col] for col in parent.columns}
-            else:
-                dtypes = {parent.columns: self.operand("dtypes")[parent.columns]}
+            dtypes = {col: self.operand("dtypes")[col] for col in parent.columns}
             out = Timeseries(
                 self.start,
                 self.end,

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -875,7 +875,7 @@ class RenameFrame(Blockwise):
             self.operand("columns"), Mapping
         ):
             reverse_mapping = {val: key for key, val in self.operand("columns").items()}
-            if not isinstance(parent.columns, pd.Index):
+            if is_series_like(parent._meta):
                 # Fill this out when Series.rename is implemented
                 return
             else:
@@ -1035,8 +1035,10 @@ class Projection(Elemwise):
     def columns(self):
         if isinstance(self.operand("columns"), list):
             return pd.Index(self.operand("columns"))
-        else:
+        elif isinstance(self.operand("columns"), pd.Index):
             return self.operand("columns")
+        else:
+            return pd.Index([self.operand("columns")])
 
     @property
     def _meta(self):
@@ -1057,10 +1059,12 @@ class Projection(Elemwise):
         base = str(self.frame)
         if " " in base:
             base = "(" + base + ")"
-        return f"{base}[{repr(self.columns)}]"
+        return f"{base}[{repr(self.operand('columns'))}]"
 
     def _simplify_down(self):
-        if str(self.frame.columns) == str(self.columns):
+        if str(self.frame.columns) == str(self.columns) and type(self._meta) == type(
+            self.frame._meta
+        ):
             # TODO: we should get more precise around Expr.columns types
             return self.frame
         if isinstance(self.frame, Projection):

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -1062,8 +1062,9 @@ class Projection(Elemwise):
         return f"{base}[{repr(self.operand('columns'))}]"
 
     def _simplify_down(self):
-        if str(self.frame.columns) == str(self.columns) and type(self._meta) == type(
-            self.frame._meta
+        if (
+            str(self.frame.columns) == str(self.columns)
+            and self._meta.ndim == self.frame._meta.ndim
         ):
             # TODO: we should get more precise around Expr.columns types
             return self.frame

--- a/dask_expr/reductions.py
+++ b/dask_expr/reductions.py
@@ -177,10 +177,7 @@ class DropDuplicates(Unique):
 
     def _simplify_up(self, parent):
         if self.subset is not None:
-            columns = parent.columns
-            if not isinstance(columns, pd.Index):
-                columns = [columns]
-            columns = set(columns).union(self.subset)
+            columns = set(parent.columns).union(self.subset)
             if columns == set(self.frame.columns):
                 # Don't add unnecessary Projections, protects against loops
                 return

--- a/dask_expr/repartition.py
+++ b/dask_expr/repartition.py
@@ -84,7 +84,7 @@ class Repartition(Expr):
     def _simplify_up(self, parent):
         # Reorder with column projection
         if isinstance(parent, Projection):
-            return type(self)(self.frame[parent.columns], *self.operands[1:])
+            return type(self)(self.frame[parent.operand("columns")], *self.operands[1:])
 
 
 class RepartitionToFewer(Repartition):

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -287,6 +287,12 @@ def test_clip_traverse_filters(df):
 
     assert result._name == expected._name
 
+    arg = df.clip(lower=10)[["x"]]
+    result = optimize(arg, fuse=False)
+    expected = df[["x"]].clip(lower=10)
+
+    assert result._name == expected._name
+
 
 @pytest.mark.parametrize("projection", ["zz", ["zz"], ["zz", "x"], "zz"])
 @pytest.mark.parametrize("subset", ["x", ["x"]])


### PR DESCRIPTION
We've discussed this a couple of weeks ago. Generally, we can make ``.columns`` always return and Index/list (Index makes sense in case we want to use the built-in methods (difference, union, intersection), otherwise we can simply use a list @rjzamora could you weigh in here whether using Index specific methods is ok for cudf?)

Most cases don't care about the difference for columns, e.g. whether it's a list-like or a scalar. These paths can just use ``parent.columns`` and be done with it. We have to be careful that we don't use ``parent.columns`` when pushing a projection up, since this would change behaviour, e.g.

```
df["a"] -> Series
df[["a"]] -> DataFrame
```

Using ``parent.operand("columns")`` consistently solves this problem.

We have a few other cases where the difference between a list-like and a scalar matters, e.g.:

```
pdf = pd.DataFrame({"a": [1, 2, 3]})
df = from_pandas(pdf)

df[["a"]] -> this should kill the projection since it is a no-op
df["a"] -> this should preserve the projection, since we coerce to a Series
```

Simply checking ``self.frame.columns == self.columns`` won't work anymore, since we cast ``"a"`` to ``pd.Index(["a"])``, which makes them seem equal. 

There are probably a few ways in which we can solve this, the one I've chosen for now is to check ``type(self.frame._meta) == type(self._meta)`` for equality. This is a pattern we should probably generalise, since we will need this in different places.




