### PR TITLE
Handle shuffle method name for upcoming ``dask`` release

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -4,7 +4,9 @@ channels:
 dependencies:
   - pytest
   - pytest-cov
-  - dask
+  - dask  # overridden by git tip below
   - pyarrow
   - pandas>=2
   - pre-commit
+  - pip:
+      - git+https://github.com/dask/dask

--- a/dask_expr/shuffle.py
+++ b/dask_expr/shuffle.py
@@ -15,7 +15,13 @@ from dask.dataframe.shuffle import (
     shuffle_group_2,
     shuffle_group_get,
 )
-from dask.utils import digit, get_default_shuffle_algorithm, insert
+from dask.utils import digit, insert
+
+try:
+    from dask.utils import get_default_shuffle_method
+except ImportError:
+    # Fallback to old name for `dask<=2023.6.0`
+    from dask.utils import get_default_shuffle_algorithm as get_default_shuffle_method
 
 from dask_expr.expr import Blockwise, Expr, PartitionsFiltered, Projection
 from dask_expr.reductions import (
@@ -85,7 +91,7 @@ class Shuffle(Expr):
         # Use `backend` to decide how to compose a
         # shuffle operation from concerete expressions
         # TODO: Support "p2p"
-        backend = self.backend or get_default_shuffle_algorithm()
+        backend = self.backend or get_default_shuffle_method()
         backend = "tasks" if backend == "p2p" else backend
         if hasattr(backend, "from_abstract_shuffle"):
             return backend.from_abstract_shuffle(self)

--- a/dask_expr/shuffle.py
+++ b/dask_expr/shuffle.py
@@ -15,13 +15,7 @@ from dask.dataframe.shuffle import (
     shuffle_group_2,
     shuffle_group_get,
 )
-from dask.utils import digit, insert
-
-try:
-    from dask.utils import get_default_shuffle_method
-except ImportError:
-    # Fallback to old name for `dask<=2023.6.0`
-    from dask.utils import get_default_shuffle_algorithm as get_default_shuffle_method
+from dask.utils import digit, get_default_shuffle_method, insert
 
 from dask_expr.expr import Blockwise, Expr, PartitionsFiltered, Projection
 from dask_expr.reductions import (


### PR DESCRIPTION
This method will change names in the upcoming `dask` release next week (xref https://github.com/dask/dask/pull/10344). Handling that name change early here. 