### PR TITLE
Test against dev `dask` and `distributed`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,12 @@ jobs:
           extra-specs: |
             python=${{ matrix.python-version }}
 
+      - name: Upstream packages
+        if: ${{ matrix.python-version == '3.11' }}
+        run: |
+          python -m pip install git+https://github.com/dask/distributed
+          python -m pip install git+https://github.com/dask/dask
+
       - name: Install Dask-Match
         run: python -m pip install -e . --no-deps
 


### PR DESCRIPTION
I just happened to catch https://github.com/dask-contrib/dask-expr/pull/156 by chance. This PR takes a lightweight approach to covering dev versions of `dask` and `distributed` (just a single CI build). 