### PR TITLE
Make ``repartition`` a no-op if divisions are the same

### DIFF
--- a/dask_expr/repartition.py
+++ b/dask_expr/repartition.py
@@ -77,6 +77,8 @@ class Repartition(Expr):
                 else:
                     return RepartitionToMore(self.frame, self.n)
         elif self.new_divisions:
+            if tuple(self.new_divisions) == self.frame.divisions:
+                return self.frame
             return RepartitionDivisions(self.frame, self.new_divisions, self.force)
         else:
             raise NotImplementedError()

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -647,6 +647,11 @@ def test_repartition_divisions(df, opt):
             assert part.max() < df2.divisions[p + 1]
 
 
+def test_repartition_no_op(df):
+    result = df.repartition(divisions=df.divisions).optimize()
+    assert result._name == df._name
+
+
 def test_len(df, pdf):
     df2 = df[["x"]] + 1
     assert len(df2) == len(pdf)


### PR DESCRIPTION
This addresses the comment from the align pr