### PR TITLE
Change incorrect Projection test

### DIFF
--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -446,12 +446,6 @@ def test_remove_unnecessary_projections(df):
 
     assert optimized._name == expected._name
 
-    result = (df.x + 1)["x"]
-    optimized = optimize(result, fuse=False)
-    expected = df.x + 1
-
-    assert optimized._name == expected._name
-
 
 def test_substitute(df):
     pdf = pd.DataFrame(

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -446,6 +446,12 @@ def test_remove_unnecessary_projections(df):
 
     assert optimized._name == expected._name
 
+    result = (df[["x"]] + 1)[["x"]]
+    optimized = optimize(result, fuse=False)
+    expected = df[["x"]] + 1
+
+    assert optimized._name == expected._name
+
 
 def test_substitute(df):
     pdf = pd.DataFrame(


### PR DESCRIPTION
The last commit broke ci because of other changes on main since then. 

The test that I changed was incorrect, doing ``df["x"]`` will reduce to a Series, selecting ``x`` again would reduce to a scalar, so we can't just get rid of the Projection.