### PR TITLE
Implement ``simplify_up`` for ``combine_first``

### DIFF
--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -927,6 +927,30 @@ class CombineFirst(Blockwise):
     _parameters = ["frame", "other"]
     operation = M.combine_first
 
+    @functools.cached_property
+    def _meta(self):
+        return make_meta(
+            self.operation(
+                meta_nonempty(self.frame._meta),
+                meta_nonempty(self.other._meta),
+            ),
+        )
+
+    def _simplify_up(self, parent):
+        if isinstance(parent, Projection):
+            columns = parent.columns
+            frame_columns = sorted(set(columns).intersection(self.frame.columns))
+            other_columns = sorted(set(columns).intersection(self.other.columns))
+            if (
+                self.frame.columns == frame_columns
+                and self.other.columns == other_columns
+            ):
+                return
+            return type(parent)(
+                type(self)(self.frame[frame_columns], self.other[other_columns]),
+                *parent.operands[1:],
+            )
+
 
 class RenameFrame(Blockwise):
     _parameters = ["frame", "columns"]

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -301,6 +301,18 @@ def test_repr(df):
     assert "sum(skipna=False)" in s
 
 
+def test_combine_first_simplify(pdf):
+    df = from_pandas(pdf)
+    pdf2 = pdf.rename(columns={"y": "z"})
+    df2 = from_pandas(pdf2)
+
+    q = df.combine_first(df2)[["z", "y"]]
+    result = q.simplify()
+    expected = df[["y"]].combine_first(df2[["z"]])[["z", "y"]]
+    assert result._name == expected._name
+    assert_eq(result, pdf.combine_first(pdf2)[["z", "y"]])
+
+
 def test_rename_traverse_filter(df):
     result = optimize(df.rename(columns={"x": "xx"})[["xx"]], fuse=False)
     expected = df[["x"]].rename(columns={"x": "xx"})


### PR DESCRIPTION
This needs an alignment step as well, but adding it will be easier after #166 is merged, so holding off till then.

Empty objects in ``combine_first`` ignore ``other``, which makes result-column inference buggy.