### PR TITLE
Tail failing when doing repartition beforehand

### DIFF
--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -1383,7 +1383,7 @@ class Tail(Expr):
             return type(self.frame)(*operands)
         if not isinstance(self, BlockwiseTail):
             # Lower to Blockwise
-            return BlockwiseTail(Partitions(self.frame, [-1]), self.n)
+            return BlockwiseTail(Partitions(self.frame, [self.npartitions - 1]), self.n)
         if isinstance(self.frame, Tail):
             return Tail(self.frame.frame, min(self.n, self.frame.n))
 

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -1383,7 +1383,9 @@ class Tail(Expr):
             return type(self.frame)(*operands)
         if not isinstance(self, BlockwiseTail):
             # Lower to Blockwise
-            return BlockwiseTail(Partitions(self.frame, [self.npartitions - 1]), self.n)
+            return BlockwiseTail(
+                Partitions(self.frame, [self.frame.npartitions - 1]), self.n
+            )
         if isinstance(self.frame, Tail):
             return Tail(self.frame.frame, min(self.n, self.frame.n))
 

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -436,6 +436,12 @@ def test_tail_tail(df):
     assert a.optimize()._name == b.optimize()._name
 
 
+def test_tail_repartition(df):
+    a = df.repartition(npartitions=10).tail()
+    b = df.tail()
+    assert_eq(a, b)
+
+
 def test_projection_stacking(df):
     result = df[["x", "y"]]["x"]
     optimized = result.simplify()


### PR DESCRIPTION
Ran into this when working on a POC for lowering and aligning

I wasn't sure whether or not we wanted to support negative indices more generally, if yes we have to do this in ``Partitions``