### PR TITLE
Ensure that ``divisions`` are available after ``set_index``

### DIFF
--- a/dask_expr/shuffle.py
+++ b/dask_expr/shuffle.py
@@ -671,10 +671,15 @@ class SetPartition(SetIndex):
         )
 
         if isinstance(self._other, Expr):
-            index_set = _SetIndexPostSeries(shuffled, self.other._meta.name)
+            index_set = _SetIndexPostSeries(
+                shuffled, self.other._meta.name, new_divisions=self._divisions()
+            )
         else:
             index_set = _SetIndexPostScalar(
-                shuffled, self.other._meta.name, drop=self.drop
+                shuffled,
+                self.other._meta.name,
+                drop=self.drop,
+                new_divisions=self._divisions(),
             )
 
         return SortIndexBlockwise(index_set)
@@ -691,17 +696,23 @@ class _SetPartitionsPreSetIndex(Blockwise):
 
 
 class _SetIndexPostScalar(Blockwise):
-    _parameters = ["frame", "index_name", "drop"]
+    _parameters = ["frame", "index_name", "drop", "new_divisions"]
 
-    def operation(self, df, index_name, drop):
+    def _divisions(self):
+        return self.new_divisions
+
+    def operation(self, df, index_name, drop, new_divisions):
         df2 = df.set_index(index_name, drop=drop)
         return df2
 
 
 class _SetIndexPostSeries(Blockwise):
-    _parameters = ["frame", "index_name"]
+    _parameters = ["frame", "index_name", "new_divisions"]
 
-    def operation(self, df, index_name):
+    def _divisions(self):
+        return self.new_divisions
+
+    def operation(self, df, index_name, new_divisions):
         df2 = df.set_index("_index", drop=True)
         df2.index.name = index_name
         return df2

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -134,5 +134,10 @@ def test_set_index(df, pdf):
     assert_eq(df.set_index("x"), pdf.set_index("x"))
     assert_eq(df.set_index(df.x), pdf.set_index(pdf.x))
 
+    q = df.set_index("x").simplify()
+    assert not all(div is None for div in q.divisions)
+    q = df.set_index(df.x).simplify()
+    assert not all(div is None for div in q.divisions)
+
     with pytest.raises(TypeError, match="can't be of type DataFrame"):
         df.set_index(df)


### PR DESCRIPTION
I missed that initially. We should make them available if we know them like here