### PR TITLE
Implement ``rename_axis``

### DIFF
--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -103,7 +103,7 @@ class FrameBase(DaskMethodsMixin):
 
     @property
     def columns(self):
-        return pd.Index(self.expr.columns)
+        return pd.Index(self.expr.columns, name=self._meta.columns.name)
 
     def __len__(self):
         return new_collection(Len(self.expr)).compute()

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -469,6 +469,11 @@ class Expr:
     def replace(self, to_replace=None, value=no_default, regex=False):
         return Replace(self, to_replace=to_replace, value=value, regex=regex)
 
+    def rename_axis(
+        self, mapper=no_default, index=no_default, columns=no_default, axis=0
+    ):
+        return RenameAxis(self, mapper=mapper, index=index, columns=columns, axis=axis)
+
     def align(self, other, join="outer", fill_value=None):
         from dask_expr.collection import new_collection
         from dask_expr.repartition import Repartition
@@ -1169,6 +1174,19 @@ class Abs(Elemwise):
     _projection_passthrough = True
     _parameters = ["frame"]
     operation = M.abs
+
+
+class RenameAxis(Elemwise):
+    _projection_passthrough = True
+    _parameters = ["frame", "mapper", "index", "columns", "axis"]
+    _defaults = {
+        "mapper": no_default,
+        "index": no_default,
+        "columns": no_default,
+        "axis": 0,
+    }
+    _keyword_only = ["mapper", "index", "columns", "axis"]
+    operation = M.rename_axis
 
 
 class Apply(Elemwise):

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -291,6 +291,15 @@ def test_blockwise(func, pdf, df):
     assert_eq(func(pdf), func(df))
 
 
+def test_rename_axis(pdf):
+    pdf.index.name = "a"
+    pdf.columns.name = "b"
+    df = from_pandas(pdf, npartitions=10)
+    assert_eq(df.rename_axis(index="dummy"), pdf.rename_axis(index="dummy"))
+    assert_eq(df.rename_axis(columns="dummy"), pdf.rename_axis(columns="dummy"))
+    assert_eq(df.x.rename_axis(index="dummy"), pdf.x.rename_axis(index="dummy"))
+
+
 def test_isin(df, pdf):
     values = [1, 2]
     assert_eq(pdf.isin(values), df.isin(values))


### PR DESCRIPTION
This is a useful utility that enables method chaining when renaming one of the axes

Discovered a bug while implementing this, we can't preserve the names of our columns, is fixed here