### PR TITLE
Implement ``sorted`` keyword for ``set_index``

### DIFF
--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -39,7 +39,7 @@ from dask_expr.reductions import (
     ValueCounts,
 )
 from dask_expr.repartition import Repartition
-from dask_expr.shuffle import SetIndex
+from dask_expr.shuffle import SetIndex, SetIndexBlockwise
 
 #
 # Utilities to wrap Expr API
@@ -737,8 +737,14 @@ class DataFrame(FrameBase):
         if divisions is not None:
             check_divisions(divisions)
         other = other.expr if isinstance(other, Series) else other
+
+        if sorted:
+            return new_collection(
+                SetIndexBlockwise(self.expr, other, drop, new_divisions=divisions)
+            )
+
         return new_collection(
-            SetIndex(self.expr, other, drop, sorted, user_divisions=divisions)
+            SetIndex(self.expr, other, drop, user_divisions=divisions)
         )
 
 

--- a/dask_expr/shuffle.py
+++ b/dask_expr/shuffle.py
@@ -642,14 +642,12 @@ class SetIndex(Expr):
         "frame",
         "_other",
         "drop",
-        "sorted",
         "user_divisions",
         "partition_size",
         "ascending",
     ]
     _defaults = {
         "drop": True,
-        "sorted": False,
         "user_divisions": None,
         "partition_size": 128e6,
         "ascending": True,
@@ -786,7 +784,21 @@ class SetIndexBlockwise(Blockwise):
         return df.set_index(*args, **kwargs)
 
     def _divisions(self):
+        if self.new_divisions is None:
+            return (None,) * (self.frame.npartitions + 1)
         return tuple(self.new_divisions)
+
+    def _simplify_up(self, parent):
+        if isinstance(parent, Projection):
+            columns = parent.columns + (
+                [self.other] if not isinstance(self.other, Expr) else []
+            )
+            if self.frame.columns == columns:
+                return
+            return type(parent)(
+                type(self)(self.frame[columns], *self.operands[1:]),
+                parent.operand("columns"),
+            )
 
 
 @functools.lru_cache  # noqa: B019


### PR DESCRIPTION
Not implementing the divisions compute call if the index is already sorted for now.