### PR TITLE
Enforce deterministic ``tokenize`` everywhere

### DIFF
--- a/dask_expr/_util.py
+++ b/dask_expr/_util.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from dask import config
+from dask.base import tokenize
+
 
 def _convert_to_list(column) -> list | None:
     if column is None or isinstance(column, list):
@@ -11,3 +14,8 @@ def _convert_to_list(column) -> list | None:
     else:
         column = [column]
     return column
+
+
+def _tokenize_deterministic(*args, **kwargs):
+    with config.set({"tokenize.ensure-deterministic": True}):
+        return tokenize(*args, **kwargs)

--- a/dask_expr/_util.py
+++ b/dask_expr/_util.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from types import LambdaType
+
 from dask import config
-from dask.base import tokenize
+from dask.base import normalize_token, tokenize
 
 
 def _convert_to_list(column) -> list | None:
@@ -16,6 +18,12 @@ def _convert_to_list(column) -> list | None:
     return column
 
 
+@normalize_token.register(LambdaType)
+def _normalize_lambda(func):
+    return str(func)
+
+
 def _tokenize_deterministic(*args, **kwargs):
+    # Utility to be strict about deterministic tokens
     with config.set({"tokenize.ensure-deterministic": True}):
         return tokenize(*args, **kwargs)

--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -23,7 +23,7 @@ from fsspec.utils import stringify_path
 from tlz import first
 
 from dask_expr import expr
-from dask_expr._util import _convert_to_list, _wrap_lambdas
+from dask_expr._util import _convert_to_list
 from dask_expr.align import AlignPartitions
 from dask_expr.concat import Concat
 from dask_expr.expr import Eval, no_default
@@ -374,7 +374,7 @@ class FrameBase(DaskMethodsMixin):
             raise NotImplementedError()
         new_expr = expr.MapPartitions(
             self.expr,
-            _wrap_lambdas(func),
+            func,
             meta,
             enforce_metadata,
             transform_divisions,
@@ -655,9 +655,7 @@ class DataFrame(FrameBase):
         return list(o)
 
     def map(self, func, na_action=None):
-        return new_collection(
-            expr.Map(self.expr, arg=_wrap_lambdas(func), na_action=na_action)
-        )
+        return new_collection(expr.Map(self.expr, arg=func, na_action=na_action))
 
     def __repr__(self):
         return f"<dask_expr.expr.DataFrame: expr={self.expr}>"
@@ -779,9 +777,7 @@ class Series(FrameBase):
         return new_collection(self.expr.nbytes)
 
     def map(self, arg, na_action=None):
-        return new_collection(
-            expr.Map(self.expr, arg=_wrap_lambdas(arg), na_action=na_action)
-        )
+        return new_collection(expr.Map(self.expr, arg=arg, na_action=na_action))
 
     def __repr__(self):
         return f"<dask_expr.expr.Series: expr={self.expr}>"

--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -23,7 +23,7 @@ from fsspec.utils import stringify_path
 from tlz import first
 
 from dask_expr import expr
-from dask_expr._util import _convert_to_list
+from dask_expr._util import _convert_to_list, _wrap_lambdas
 from dask_expr.align import AlignPartitions
 from dask_expr.concat import Concat
 from dask_expr.expr import Eval, no_default
@@ -374,7 +374,7 @@ class FrameBase(DaskMethodsMixin):
             raise NotImplementedError()
         new_expr = expr.MapPartitions(
             self.expr,
-            func,
+            _wrap_lambdas(func),
             meta,
             enforce_metadata,
             transform_divisions,
@@ -655,7 +655,9 @@ class DataFrame(FrameBase):
         return list(o)
 
     def map(self, func, na_action=None):
-        return new_collection(expr.Map(self.expr, arg=func, na_action=na_action))
+        return new_collection(
+            expr.Map(self.expr, arg=_wrap_lambdas(func), na_action=na_action)
+        )
 
     def __repr__(self):
         return f"<dask_expr.expr.DataFrame: expr={self.expr}>"
@@ -777,7 +779,9 @@ class Series(FrameBase):
         return new_collection(self.expr.nbytes)
 
     def map(self, arg, na_action=None):
-        return new_collection(expr.Map(self.expr, arg=arg, na_action=na_action))
+        return new_collection(
+            expr.Map(self.expr, arg=_wrap_lambdas(arg), na_action=na_action)
+        )
 
     def __repr__(self):
         return f"<dask_expr.expr.Series: expr={self.expr}>"
@@ -897,10 +901,12 @@ def from_dask_dataframe(ddf: _Frame, optimize: bool = True) -> FrameBase:
     return from_graph(graph, ddf._meta, ddf.divisions, ddf._name)
 
 
-def read_csv(*args, **kwargs):
+def read_csv(path, *args, **kwargs):
     from dask_expr.io.csv import ReadCSV
 
-    return new_collection(ReadCSV(*args, **kwargs))
+    if not isinstance(path, str):
+        path = stringify_path(path)
+    return new_collection(ReadCSV(path, *args, **kwargs))
 
 
 def read_parquet(
@@ -923,7 +929,7 @@ def read_parquet(
 ):
     from dask_expr.io.parquet import ReadParquet
 
-    if hasattr(path, "name"):
+    if not isinstance(path, str):
         path = stringify_path(path)
 
     kwargs["dtype_backend"] = dtype_backend

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -27,7 +27,7 @@ from dask.dataframe.utils import clear_known_categories, drop_by_shallow_copy
 from dask.utils import M, apply, funcname, import_required, is_arraylike
 from tlz import merge_sorted, unique
 
-from dask_expr._util import _tokenize_deterministic
+from dask_expr._util import _tokenize_deterministic, _wrap_lambdas
 
 replacement_rules = []
 
@@ -466,7 +466,7 @@ class Expr:
         return Round(self, decimals=decimals)
 
     def apply(self, function, *args, **kwargs):
-        return Apply(self, function, args, kwargs)
+        return Apply(self, _wrap_lambdas(function), args, kwargs)
 
     def replace(self, to_replace=None, value=no_default, regex=False):
         return Replace(self, to_replace=to_replace, value=value, regex=regex)

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -27,7 +27,7 @@ from dask.dataframe.utils import clear_known_categories, drop_by_shallow_copy
 from dask.utils import M, apply, funcname, import_required, is_arraylike
 from tlz import merge_sorted, unique
 
-from dask_expr._util import _tokenize_deterministic, _wrap_lambdas
+from dask_expr._util import _tokenize_deterministic
 
 replacement_rules = []
 
@@ -466,7 +466,7 @@ class Expr:
         return Round(self, decimals=decimals)
 
     def apply(self, function, *args, **kwargs):
-        return Apply(self, _wrap_lambdas(function), args, kwargs)
+        return Apply(self, function, args, kwargs)
 
     def replace(self, to_replace=None, value=no_default, regex=False):
         return Replace(self, to_replace=to_replace, value=value, regex=regex)


### PR DESCRIPTION
While pushing on #212, I realized that we are currently getting non-deterministic tokenization for objects other than `cudf`. I also discovered that `dask.base.tokenize` supports a valuable `"tokenize.ensure-deterministic"` configuration option. This PR adds a new `_tokenize_deterministic` utility to make sure we catch any case where a deterministic token cannot be produced.