### PR TITLE
Test and use ``substitute_parameters`` method

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -695,7 +695,7 @@ class Expr:
             return type(self)(*new)
         return self
 
-    def _substitute_parameters(self, substitutions: dict) -> Expr:
+    def substitute_parameters(self, substitutions: dict) -> Expr:
         """Substitute specific `Expr` parameters
 
         Parameters
@@ -1877,11 +1877,7 @@ class Partitions(Expr):
                 partitions = self.partitions
             # We assume that expressions defining a special "_partitions"
             # parameter can internally capture the same logic as `Partitions`
-            operands = [
-                partitions if self.frame._parameters[i] == "_partitions" else op
-                for i, op in enumerate(self.frame.operands)
-            ]
-            return type(self.frame)(*operands)
+            return self.frame.substitute_parameters({"_partitions": partitions})
 
     def _node_label_args(self):
         return [self.frame, self.partitions]

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -533,6 +533,31 @@ def test_substitute(df):
     assert result._name == expected._name
 
 
+def test_substitute_parameters(df):
+    pdf = pd.DataFrame(
+        {
+            "a": range(100),
+            "b": range(100),
+            "c": range(100),
+            "index": range(100, 0, -1),
+        }
+    )
+    df = from_pandas(pdf, npartitions=3, sort=True)
+
+    result = df.substitute_parameters({"sort": False})
+    assert result._name != df._name
+    assert result._name == from_pandas(pdf, npartitions=3, sort=False)._name
+
+    result = df.substitute_parameters({"npartitions": 2, "sort": False})
+    assert result._name != df._name
+    assert result._name == from_pandas(pdf, npartitions=2, sort=False)._name
+
+    df2 = df[["a", "b"]]
+    result = df2.substitute_parameters({"columns": "c"})
+    assert result._name != df2._name
+    assert result._name == df["c"]._name
+
+
 def test_from_pandas(pdf):
     df = from_pandas(pdf, npartitions=3)
     assert df.npartitions == 3


### PR DESCRIPTION
Follow-up to #220

- Makes `_substitute_parameters` into a "public" `Expr.substitute_parameters` method
- Adds test coverage
- Uses the method in a few places to simplify redundant code