### PR TITLE
Lower ``ApplyConcatApply`` into ``Chunk`` and ``TreeReduce``

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2055,8 +2055,7 @@ def optimize_blockwise_fusion(expr):
             if v == set() or all(not isinstance(_expr, Blockwise) for _expr in v)
         ]
         while roots:
-            # Need to pop roots in FIFO order
-            root = roots.pop(0)
+            root = roots.pop()
             seen = set()
             stack = [root]
             group = []
@@ -2080,7 +2079,9 @@ def optimize_blockwise_fusion(expr):
                         # of partitions, since broadcasting within
                         # a group is not allowed.
                         stack.append(dep)
-                    elif dep not in roots and dependencies[dep]:
+                    elif dependencies[dep] and dep._name not in [
+                        r._name for r in roots
+                    ]:
                         # Couldn't fuse dep, but we may be able to
                         # use it as a new root on the next pass
                         roots.append(dep)

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2055,7 +2055,8 @@ def optimize_blockwise_fusion(expr):
             if v == set() or all(not isinstance(_expr, Blockwise) for _expr in v)
         ]
         while roots:
-            root = roots.pop()
+            # Need to pop roots in FIFO order
+            root = roots.pop(0)
             seen = set()
             stack = [root]
             group = []

--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -101,7 +101,7 @@ class ApplyConcatApply(Expr):
 class Chunk(Blockwise):
     """Partition-wise component of `ApplyConcatApply`
 
-    This class is used within `ApplyConcatApply._simplify_down`.
+    This class is used within `ApplyConcatApply._lower`.
 
     See Also
     --------
@@ -141,6 +141,15 @@ class Chunk(Blockwise):
 
 
 class TreeReduce(Expr):
+    """Tree-reduction component of `ApplyConcatApply`
+
+    This class is used within `ApplyConcatApply._lower`.
+
+    See Also
+    --------
+    ApplyConcatApply
+    """
+
     _parameters = [
         "frame",
         "kind",

--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -108,7 +108,7 @@ class Chunk(Blockwise):
     ApplyConcatApply
     """
 
-    _parameters = ["frame", "type", "chunk", "chunk_kwargs"]
+    _parameters = ["frame", "kind", "chunk", "chunk_kwargs"]
 
     def operation(self, *args, **kwargs):
         return self.chunk(*args, **kwargs)
@@ -122,7 +122,7 @@ class Chunk(Blockwise):
         return self.chunk_kwargs or {}
 
     def _tree_repr_lines(self, indent=0, recursive=True):
-        header = f"{funcname(self.type)}({funcname(type(self))}): "
+        header = f"{funcname(self.kind)}({funcname(type(self))}): "
         lines = []
         if recursive:
             for dep in self.dependencies():
@@ -130,7 +130,7 @@ class Chunk(Blockwise):
 
         for k, v in self.chunk_kwargs.items():
             try:
-                if v != self.type._defaults[k]:
+                if v != self.kind._defaults[k]:
                     header += f" {k}={v}"
             except KeyError:
                 header += f" {k}={v}"
@@ -143,7 +143,7 @@ class Chunk(Blockwise):
 class TreeReduce(Expr):
     _parameters = [
         "frame",
-        "type",
+        "kind",
         "_meta",
         "combine",
         "aggregate",
@@ -191,8 +191,13 @@ class TreeReduce(Expr):
     def _divisions(self):
         return (None, None)
 
+    def __str__(self):
+        chunked = str(self.frame)
+        split_every = getattr(self, "split_every", 0)
+        return f"{type(self).__name__}({chunked}, kind={funcname(self.kind)}, split_every={split_every})"
+
     def _tree_repr_lines(self, indent=0, recursive=True):
-        header = f"{funcname(self.type)}({funcname(type(self))}): "
+        header = f"{funcname(self.kind)}({funcname(type(self))}): "
         lines = []
         if recursive:
             for dep in self.dependencies():

--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -122,7 +122,7 @@ class Chunk(Blockwise):
         return self.chunk_kwargs or {}
 
     def _tree_repr_lines(self, indent=0, recursive=True):
-        header = f"{funcname(self.kind)}({funcname(type(self))}): "
+        header = f"{funcname(self.kind)}({funcname(type(self))}):"
         lines = []
         if recursive:
             for dep in self.dependencies():
@@ -206,7 +206,7 @@ class TreeReduce(Expr):
         return f"{type(self).__name__}({chunked}, kind={funcname(self.kind)}, split_every={split_every})"
 
     def _tree_repr_lines(self, indent=0, recursive=True):
-        header = f"{funcname(self.kind)}({funcname(type(self))}): "
+        header = f"{funcname(self.kind)}({funcname(type(self))}):"
         lines = []
         if recursive:
             for dep in self.dependencies():

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -62,9 +62,9 @@ def df_bc(fn):
         ),
     ],
 )
-def test_optimize(tmpdir, input, expected):
+def test_simplify(tmpdir, input, expected):
     fn = _make_file(tmpdir, format="parquet")
-    result = optimize(input(fn), fuse=False)
+    result = input(fn).simplify()
     assert str(result.expr) == str(expected(fn).expr)
 
 

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -653,19 +653,31 @@ def test_tree_repr(df, fuse):
 
     df = timeseries()
     expr = ((df.x + 1).sum(skipna=False) + df.y.mean()).expr
-    expr = expr.optimize() if fuse else expr
-    s = expr.tree_repr()
 
-    assert "Sum" in s
-    assert "Add" in s
-    assert "1" in s
+    # Check result before optimization
+    s = expr.tree_repr()
+    assert "Sum:" in s
+    assert "Add:" in s
+    assert "Mean:" in s
+    assert "AlignPartitions:" in s
+    assert str(df.seed) in s.lower()
+
+    # Check result after optimization
+    optimized = expr.optimize(fuse=fuse)
+    s = optimized.tree_repr()
+    assert "Sum(Chunk):" in s
+    assert "Sum(TreeReduce): split_every=0" in s
+    assert "Add:" in s
+    assert "Mean:" not in s
+    assert "AlignPartitions:" not in s
+    assert "right=1" in s
     assert "True" not in s
     assert "None" not in s
     assert "skipna=False" in s
     assert str(df.seed) in s.lower()
     if fuse:
         assert "Fused" in s
-        assert s.count("|") == 10
+        assert "|" in s
 
 
 def test_simple_graphs(df):

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -649,7 +649,7 @@ def test_tree_repr(df, fuse):
     assert str(df.seed) in s.lower()
     if fuse:
         assert "Fused" in s
-        assert s.count("|") == 9
+        assert s.count("|") == 10
 
 
 def test_simple_graphs(df):

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -124,12 +124,12 @@ def test_shuffle_column_projection(df):
 
 
 def test_shuffle_reductions(df):
-    assert df.shuffle("x").sum().optimize()._name == df.sum()._name
+    assert df.shuffle("x").sum().simplify()._name == df.sum()._name
 
 
 @pytest.mark.xfail(reason="Shuffle can't see the reduction through the Projection")
 def test_shuffle_reductions_after_projection(df):
-    assert df.shuffle("x").y.sum().optimize()._name == df.y.sum()._name
+    assert df.shuffle("x").y.sum().simplify()._name == df.y.sum()._name
 
 
 def test_set_index(df, pdf):


### PR DESCRIPTION
In preparation for shuffle-based groupby support, this PR breaks the general `ApplyConcatApply` expression into a blockwise `Chunk`, followed by a `TreeReduce`. The immediate result of this work is that the "chunk" component of a groupby aggregation can be fused with other `Blockwise` operations:

```python
import dask_expr as dx
import pandas as pd

pdf = pd.DataFrame({"x": list(range(10)) * 10, "y": range(100), "z": 1})
df = dx.from_pandas(pdf, npartitions=4)

agg = df.groupby("x").y.sum()
agg.optimize().pprint()
```
```
Sum(TreeReduce):  split_every=0
  Fused(32411):
  | Sum(Chunk):  chunk=<methodcaller: sum> columns=y by=['x'] numeric_only=False
  |   Projection: columns=['x', 'y']
  |     FromPandas: frame='<pandas>' npartitions=4
```

In the future, this change also makes it easier to implement a shuffle-based reduction for `split_out > 1`.