### PR TITLE
Add ``var`` and ``std`` implementations

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -436,6 +436,9 @@ class FrameBase(DaskMethodsMixin):
     def prod(self, skipna=True, numeric_only=False, min_count=0):
         return new_collection(self.expr.prod(skipna, numeric_only, min_count))
 
+    def var(self, axis=0, skipna=True, ddof=1, numeric_only=False):
+        return new_collection(self.expr.var(axis, skipna, ddof, numeric_only))
+
     def mean(self, skipna=True, numeric_only=False, min_count=0):
         return new_collection(self.expr.mean(skipna, numeric_only))
 

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -439,6 +439,9 @@ class FrameBase(DaskMethodsMixin):
     def var(self, axis=0, skipna=True, ddof=1, numeric_only=False):
         return new_collection(self.expr.var(axis, skipna, ddof, numeric_only))
 
+    def std(self, axis=0, skipna=True, ddof=1, numeric_only=False):
+        return new_collection(self.expr.std(axis, skipna, ddof, numeric_only))
+
     def mean(self, skipna=True, numeric_only=False, min_count=0):
         return new_collection(self.expr.mean(skipna, numeric_only))
 

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from collections.abc import Generator, Mapping
 
 import dask
+import numpy as np
 import pandas as pd
 import toolz
 from dask.base import normalize_token
@@ -503,6 +504,9 @@ class Expr:
             return VarColumns(self, skipna, ddof, numeric_only)
         else:
             raise ValueError(f"axis={axis} not supported. Please specify 0 or 1")
+
+    def std(self, axis=0, skipna=True, ddof=1, numeric_only=False):
+        return Sqrt(self.var(axis, skipna, ddof, numeric_only))
 
     def mean(self, skipna=True, numeric_only=False, min_count=0):
         return Mean(self, skipna=skipna, numeric_only=numeric_only)
@@ -1238,6 +1242,11 @@ class VarColumns(Blockwise):
     @functools.cached_property
     def _kwargs(self) -> dict:
         return {"axis": 1, **super()._kwargs}
+
+
+class Sqrt(Blockwise):
+    _parameters = ["frame"]
+    operation = np.sqrt
 
 
 class Elemwise(Blockwise):

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -500,7 +500,7 @@ class Expr:
         if axis == 0:
             return Var(self, skipna, ddof, numeric_only)
         elif axis == 1:
-            return VarColumns(axis, skipna, ddof, numeric_only)
+            return VarColumns(self, skipna, ddof, numeric_only)
         else:
             raise ValueError(f"axis={axis} not supported. Please specify 0 or 1")
 
@@ -1231,17 +1231,13 @@ class ToFrameIndex(Blockwise):
 
 class VarColumns(Blockwise):
     _parameters = ["frame", "skipna", "ddof", "numeric_only"]
-    _defaults = {"axis": 1, "skipna": True, "ddof": 1, "numeric_only": False}
-    _keyword_only = ["axis", "skipna", "ddof", "numeric_only"]
+    _defaults = {"skipna": True, "ddof": 1, "numeric_only": False}
+    _keyword_only = ["skipna", "ddof", "numeric_only"]
     operation = M.var
 
-    # @functools.cached_property
-    # def _args(self) -> list:
-    #     return [self.frame]
-
-    # @functools.cached_property
-    # def _kwargs(self) -> dict:
-    #     return {"axis": 1, "skipna": self.skipna, "ddof": self.ddof, "numeric_only": self.numeric_only}
+    @functools.cached_property
+    def _kwargs(self) -> dict:
+        return {"axis": 1, **super()._kwargs}
 
 
 class Elemwise(Blockwise):

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -496,6 +496,14 @@ class Expr:
     def prod(self, skipna=True, numeric_only=False, min_count=0):
         return Prod(self, skipna, numeric_only, min_count)
 
+    def var(self, axis=0, skipna=True, ddof=1, numeric_only=False):
+        if axis == 0:
+            return Var(self, skipna, ddof, numeric_only)
+        elif axis == 1:
+            return VarColumns(axis, skipna, ddof, numeric_only)
+        else:
+            raise ValueError(f"axis={axis} not supported. Please specify 0 or 1")
+
     def mean(self, skipna=True, numeric_only=False, min_count=0):
         return Mean(self, skipna=skipna, numeric_only=numeric_only)
 
@@ -1219,6 +1227,21 @@ class ToFrameIndex(Blockwise):
     _defaults = {"name": no_default, "index": True}
     _keyword_only = ["name", "index"]
     operation = M.to_frame
+
+
+class VarColumns(Blockwise):
+    _parameters = ["frame", "skipna", "ddof", "numeric_only"]
+    _defaults = {"axis": 1, "skipna": True, "ddof": 1, "numeric_only": False}
+    _keyword_only = ["axis", "skipna", "ddof", "numeric_only"]
+    operation = M.var
+
+    # @functools.cached_property
+    # def _args(self) -> list:
+    #     return [self.frame]
+
+    # @functools.cached_property
+    # def _kwargs(self) -> dict:
+    #     return {"axis": 1, "skipna": self.skipna, "ddof": self.ddof, "numeric_only": self.numeric_only}
 
 
 class Elemwise(Blockwise):
@@ -2232,5 +2255,6 @@ from dask_expr._reductions import (
     Prod,
     Size,
     Sum,
+    Var,
 )
 from dask_expr.io import IO, BlockwiseIO

--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -388,6 +388,65 @@ class NBytes(Reduction):
     reduction_aggregate = sum
 
 
+class Var(Reduction):
+    _parameters = ["frame", "skipna", "ddof", "numeric_only"]
+    _defaults = {"skipna": True, "ddof": 1, "numeric_only": False}
+
+    @property
+    def _meta(self):
+        return make_meta(
+            meta_nonempty(self.frame._meta).var(
+                numeric_only=self.numeric_only, skipna=self.skipna
+            )
+        )
+
+    @property
+    def chunk_kwargs(self):
+        return dict(skipna=self.skipna, numeric_only=self.numeric_only)
+
+    @property
+    def combine_kwargs(self):
+        return {}
+
+    @property
+    def aggregate_kwargs(self):
+        return dict(ddof=self.ddof)
+
+    @classmethod
+    def reduction_chunk(cls, x, skipna=True, numeric_only=False):
+        kwargs = {"numeric_only": numeric_only} if is_dataframe_like(x) else {}
+        if skipna:
+            n = x.count(**kwargs)
+            kwargs["skipna"] = skipna
+            avg = x.mean(**kwargs)
+        else:
+            # Not skipping nulls, so might as well
+            # avoid the full `count` operation
+            n = len(x)
+            kwargs["skipna"] = skipna
+            avg = x.sum(**kwargs) / n
+        m2 = ((x - avg) ** 2).sum(**kwargs)
+        return n, avg, m2
+
+    @classmethod
+    def reduction_combine(cls, parts):
+        n, avg, m2 = parts[0]
+        for i in range(1, len(parts)):
+            n_a, avg_a, m2_a = n, avg, m2
+            n_b, avg_b, m2_b = parts[i]
+            n = n_a + n_b
+            avg = (n_a * avg_a + n_b * avg_b) / n
+            delta = avg_b - avg_a
+            m2 = m2_a + m2_b + delta**2 * n_a * n_b / n
+        return n, avg, m2
+
+    @classmethod
+    def reduction_aggregate(cls, vals, ddof=1):
+        vals = cls.reduction_combine(vals)
+        n, _, m2 = vals
+        return m2 / (n - ddof)
+
+
 class Mean(Reduction):
     _parameters = ["frame", "skipna", "numeric_only"]
     _defaults = {"skipna": True, "numeric_only": False}

--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -389,6 +389,8 @@ class NBytes(Reduction):
 
 
 class Var(Reduction):
+    # Uses the parallel version of Welford's online algorithm (Chan 79')
+    # (http://i.stanford.edu/pub/cstr/reports/cs/tr/79/773/CS-TR-79-773.pdf)
     _parameters = ["frame", "skipna", "ddof", "numeric_only"]
     _defaults = {"skipna": True, "ddof": 1, "numeric_only": False}
 
@@ -396,7 +398,7 @@ class Var(Reduction):
     def _meta(self):
         return make_meta(
             meta_nonempty(self.frame._meta).var(
-                numeric_only=self.numeric_only, skipna=self.skipna
+                skipna=self.skipna, numeric_only=self.numeric_only
             )
         )
 

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -105,6 +105,8 @@ def test_dask(pdf, df):
         M.prod,
         M.count,
         M.mean,
+        M.std,
+        M.var,
         M.idxmin,
         M.idxmax,
         pytest.param(
@@ -123,6 +125,20 @@ def test_reductions(func, pdf, df):
     # check_dtype False because sub-selection of columns that is pushed through
     # is not reflected in the meta calculation
     assert_eq(func(df)["x"], func(pdf)["x"], check_dtype=False)
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("skipna", [True, False])
+@pytest.mark.parametrize("ddof", [1, 2])
+def test_std_kwargs(axis, skipna, ddof):
+    pdf = pd.DataFrame(
+        {"x": range(30), "y": [1, 2, None] * 10, "z": ["dog", "cat"] * 15}
+    )
+    df = from_pandas(pdf, npartitions=3)
+    assert_eq(
+        pdf.std(axis=axis, skipna=skipna, ddof=ddof, numeric_only=True),
+        df.std(axis=axis, skipna=skipna, ddof=ddof, numeric_only=True),
+    )
 
 
 def test_nbytes(pdf, df):


### PR DESCRIPTION
Closes https://github.com/dask-contrib/dask-expr/issues/233

Adds simple ``var`` and ``std`` implementations using Welford's online algorithm.