### PR TITLE
Fix ``Binop`` column projection logic

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1742,13 +1742,13 @@ class Binop(Elemwise):
 
     def _simplify_up(self, parent):
         if isinstance(parent, Projection):
-            if isinstance(self.left, Expr):
+            if isinstance(self.left, Expr) and self.left.ndim:
                 left = self.left[
                     parent.operand("columns")
                 ]  # TODO: filter just the correct columns
             else:
                 left = self.left
-            if isinstance(self.right, Expr):
+            if isinstance(self.right, Expr) and self.right.ndim:
                 right = self.right[parent.operand("columns")]
             else:
                 right = self.right

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -503,6 +503,13 @@ def test_projection_stacking_coercion(pdf):
     assert_eq(df.x[[0]], pdf.x[[0]], check_divisions=False)
 
 
+def test_projection_pushdown_dim_0(pdf, df):
+    result = (df[["x"]] + df["x"].sum(skipna=False))["x"]
+    expected = (pdf[["x"]] + pdf["x"].sum(skipna=False))["x"]
+    assert_eq(result, expected)
+    assert_eq(result.optimize(), expected)
+
+
 def test_remove_unnecessary_projections(df):
     result = (df + 1)[df.columns]
     optimized = result.simplify()


### PR DESCRIPTION
We currently push a `Projection` operation down to both operands to a `Binop` expression. However, there is no guarantee that both operands can be indexed with a `getitem` operation. This PR adds an `ndim` check for each operand.