### PR TITLE
Implement simplify_down for Filter

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -952,6 +952,7 @@ class Blockwise(Expr):
     operation = None
     _keyword_only = []
     _projection_passthrough = False
+    _filter_passthrough = False
 
     @property
     def _required_attribute(self):
@@ -1044,7 +1045,12 @@ class Blockwise(Expr):
     def _combine_similar(self, root: Expr):
         # Push projections back up through `_projection_passthrough`
         # operations if it reduces the number of unique expression nodes.
-        if self._projection_passthrough and isinstance(self.frame, Projection):
+        if (
+            self._projection_passthrough
+            and isinstance(self.frame, Projection)
+            or self._filter_passthrough
+            and isinstance(self.frame, Filter)
+        ):
             try:
                 common = type(self)(self.frame.frame, *self.operands[1:])
             except ValueError:
@@ -1052,19 +1058,20 @@ class Blockwise(Expr):
                 # (There is no guarentee that the same method will exist for
                 # both a Series and DataFrame)
                 return None
-            projection = self.frame.operand("columns")
-            push_up_projection = False
+            operation = self.frame.operands[1]
+            push_up_op = False
             for op in self._find_similar_operations(root, ignore=self._parameters):
                 if (
-                    isinstance(op.frame, Projection)
+                    isinstance(op.frame, (Projection, Filter))
                     and (
                         common._name == type(op)(op.frame.frame, *op.operands[1:])._name
                     )
                 ) or common._name == op._name:
-                    push_up_projection = True
+                    push_up_op = True
+                    break
 
-            if push_up_projection:
-                return common[projection]
+            if push_up_op:
+                return common[operation]
         return None
 
 
@@ -1210,27 +1217,6 @@ class CombineFirst(Blockwise):
             )
 
 
-class RenameFrame(Blockwise):
-    _parameters = ["frame", "columns"]
-    _keyword_only = ["columns"]
-    operation = M.rename
-
-    def _simplify_up(self, parent):
-        if isinstance(parent, Projection) and isinstance(
-            self.operand("columns"), Mapping
-        ):
-            reverse_mapping = {val: key for key, val in self.operand("columns").items()}
-            if is_series_like(parent._meta):
-                # Fill this out when Series.rename is implemented
-                return
-            else:
-                columns = [
-                    reverse_mapping[col] if col in reverse_mapping else col
-                    for col in parent.columns
-                ]
-            return type(self)(self.frame[columns], *self.operands[1:])
-
-
 class Sample(Blockwise):
     _parameters = ["frame", "state_data", "frac", "replace"]
     operation = staticmethod(methods.sample)
@@ -1247,20 +1233,6 @@ class Sample(Blockwise):
             self.replace,
         ]
         return (self.operation,) + tuple(args)
-
-
-class ToFrame(Blockwise):
-    _parameters = ["frame", "name"]
-    _defaults = {"name": no_default}
-    _keyword_only = ["name"]
-    operation = M.to_frame
-
-
-class ToFrameIndex(Blockwise):
-    _parameters = ["frame", "index", "name"]
-    _defaults = {"name": no_default, "index": True}
-    _keyword_only = ["name", "index"]
-    operation = M.to_frame
 
 
 class VarColumns(Blockwise):
@@ -1285,7 +1257,35 @@ class Elemwise(Blockwise):
     optimizations, like `len` will care about which operations preserve length
     """
 
-    pass
+    _filter_passthrough = True
+
+    def _simplify_up(self, parent):
+        if self._filter_passthrough and isinstance(parent, Filter):
+            return type(self)(
+                self.frame[parent.operand("predicate")], *self.operands[1:]
+            )
+        return super()._simplify_up(parent)
+
+
+class RenameFrame(Elemwise):
+    _parameters = ["frame", "columns"]
+    _keyword_only = ["columns"]
+    operation = M.rename
+
+    def _simplify_up(self, parent):
+        if isinstance(parent, Projection) and isinstance(
+            self.operand("columns"), Mapping
+        ):
+            reverse_mapping = {val: key for key, val in self.operand("columns").items()}
+            if is_series_like(parent._meta):
+                # Fill this out when Series.rename is implemented
+                return
+            else:
+                columns = [
+                    reverse_mapping[col] if col in reverse_mapping else col
+                    for col in parent.columns
+                ]
+            return type(self)(self.frame[columns], *self.operands[1:])
 
 
 class Fillna(Elemwise):
@@ -1408,6 +1408,20 @@ class RenameAxis(Elemwise):
     }
     _keyword_only = ["mapper", "index", "columns", "axis"]
     operation = M.rename_axis
+
+
+class ToFrame(Elemwise):
+    _parameters = ["frame", "name"]
+    _defaults = {"name": no_default}
+    _keyword_only = ["name"]
+    operation = M.to_frame
+
+
+class ToFrameIndex(Elemwise):
+    _parameters = ["frame", "index", "name"]
+    _defaults = {"name": no_default, "index": True}
+    _keyword_only = ["name", "index"]
+    operation = M.to_frame
 
 
 class Apply(Elemwise):
@@ -1542,6 +1556,8 @@ class Filter(Blockwise):
 class Projection(Elemwise):
     """Column Selection"""
 
+    _filter_passthrough = False
+
     _parameters = ["frame", "columns"]
     operation = operator.getitem
 
@@ -1608,6 +1624,7 @@ class Index(Elemwise):
 
     _parameters = ["frame"]
     operation = getattr
+    _filter_passthrough = False
 
     @property
     def _meta(self):
@@ -1788,6 +1805,7 @@ class BlockwiseTail(Tail, Blockwise):
 
 class Binop(Elemwise):
     _parameters = ["left", "right"]
+    _filter_passthrough = False
 
     def __str__(self):
         return f"{self.left} {self._operator_repr} {self.right}"

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -1131,3 +1131,16 @@ def test_avoid_alignment():
 
     assert not any(isinstance(ex, AlignPartitions) for ex in (db.y + db.z).walk())
     assert not any(isinstance(ex, AlignPartitions) for ex in (da.x + db.y.sum()).walk())
+
+
+def test_filter_pushdown(df, pdf):
+    indexer = df.x > 5
+    result = df.replace(1, 5)[indexer].optimize(fuse=False)
+    expected = df[indexer].replace(1, 5)
+    assert result._name == expected._name
+
+    # Don't do anything here
+    df = df.replace(1, 5)
+    result = df[df.x > 5].optimize(fuse=False)
+    expected = df[df.x > 5]
+    assert result._name == expected._name


### PR DESCRIPTION
So this caused me more troubles than I'd like to admit. I think I found an issue with the ``combine_similar`` logic, it's too local.

If we end up pushing more than one operation through in simplify, we can not capture this with ``combine_similar``. Small reproducer (dropna blocks everything):

```
pdf = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6], "y": [4, 5, 8, 6, 1, 4]})
df = from_pandas(pdf, npartitions=3)

df = df.dropna().replace(1, 5)
df = df[df.x > 3][["x", "y"]]
df.optimize(fuse=False)
```

We'll end up with the following operation after simplify:

```
df = df.dropna()[["x", "y"]][df.dropna()["x"].replace(1, 5) > 3].replace(1, 5)
```

``combine_similar`` is only looking one operation ahead, which means that it won't be able to capture that both branches have the same root with ``dropna``. Ideally, we would like to restructure this to:

```
df = df.dropna().replace(1, 5)
df[["x", "y"]][df.x > 3]
```

cc @rjzamora Thoughts here?




