### PR TITLE
Absorb column projections in other ``BlockwiseIO`` expressions

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -1092,12 +1092,12 @@ def from_dask_dataframe(ddf: _Frame, optimize: bool = True) -> FrameBase:
     return from_graph(graph, ddf._meta, ddf.divisions, ddf._name)
 
 
-def read_csv(path, *args, **kwargs):
+def read_csv(path, *args, usecols=None, **kwargs):
     from dask_expr.io.csv import ReadCSV
 
     if not isinstance(path, str):
         path = stringify_path(path)
-    return new_collection(ReadCSV(path, *args, **kwargs))
+    return new_collection(ReadCSV(path, *args, columns=usecols, **kwargs))
 
 
 def read_parquet(

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1077,6 +1077,7 @@ class Blockwise(Expr):
                 for i, op in enumerate(reversed(operations)):
                     common = common[op]
                     if i > 0:
+                        # Combine stacked projections
                         common = common._simplify_down() or common
                 return common
         return None

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1184,10 +1184,6 @@ class DropnaFrame(Blockwise):
     _keyword_only = ["how", "subset", "thresh"]
     operation = M.dropna
 
-    @property
-    def _projection_passthrough(self):
-        return self.subset is None
-
     def _simplify_up(self, parent):
         if self.subset is not None:
             columns = set(parent.columns).union(self.subset)
@@ -1197,14 +1193,6 @@ class DropnaFrame(Blockwise):
 
             return type(parent)(
                 type(self)(self.frame[sorted(columns)], *self.operands[1:]),
-                *parent.operands[1:],
-            )
-        elif isinstance(parent, Projection):
-            if set(parent.columns) == set(self.frame.columns):
-                # Don't add unnecessary Projections
-                return
-            return type(parent)(
-                self.substitute_parameters({"frame": self.frame[parent.columns]}),
                 *parent.operands[1:],
             )
 

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1629,6 +1629,10 @@ class Projection(Elemwise):
         if (
             str(self.frame.columns) == str(self.columns)
             and self._meta.ndim == self.frame._meta.ndim
+            and (
+                not isinstance(self.frame, BlockwiseIO)
+                or not self.frame._absorb_projections
+            )
         ):
             # TODO: we should get more precise around Expr.columns types
             return self.frame
@@ -1646,35 +1650,6 @@ class Projection(Elemwise):
                 assert b in a
 
             return self.frame.frame[b]
-
-    # def _combine_similar(self, root: Expr):
-
-    #     projections = self._find_similar_operations(root, ignore=["columns"])
-    #     if projections:
-    #         # We have other Projection operations in the expression
-    #         # graph that can be combined with this one.
-
-    #         # Find the column-projection union
-    #         columns = set()
-    #         all_projections = [self] + projections
-    #         for projection in all_projections:
-    #             if projection.operand("columns"):
-    #                 columns |= set(projection.operand("columns"))
-    #         columns = sorted(columns)
-
-    #         # Can bail if we are not changing columns
-    #         columns_operand = self.operand("columns")
-    #         if columns_operand == columns:
-    #             return
-
-    #         # Check if we have the operation we want elsewhere in the graph
-    #         for projection in all_projections:
-    #             if projection.operand("columns") == columns:
-    #                 return projection[columns_operand]
-
-    #         # Create the "combined" Projection operation
-    #         subs = {"columns": columns}
-    #         return self.substitute_parameters(subs)[columns_operand]
 
 
 class Index(Elemwise):

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1618,9 +1618,8 @@ class Projection(Elemwise):
         if (
             str(self.frame.columns) == str(self.columns)
             and self._meta.ndim == self.frame._meta.ndim
-            and (
-                not isinstance(self.frame, BlockwiseIO)
-                or not self.frame._absorb_projections
+            and not (
+                isinstance(self.frame, BlockwiseIO) and self.frame._absorb_projections
             )
         ):
             # TODO: we should get more precise around Expr.columns types

--- a/dask_expr/_util.py
+++ b/dask_expr/_util.py
@@ -29,7 +29,20 @@ def _normalize_lambda(func):
     return str(func)
 
 
-def _tokenize_deterministic(*args, **kwargs):
+def _tokenize_deterministic(*args, **kwargs) -> str:
     # Utility to be strict about deterministic tokens
     with config.set({"tokenize.ensure-deterministic": True}):
         return tokenize(*args, **kwargs)
+
+
+def _tokenize_partial(expr, ignore: list | None = None) -> str:
+    # Helper function to "tokenize" the operands
+    # that are not in the `ignore` list
+    ignore = ignore or []
+    return _tokenize_deterministic(
+        *[
+            op
+            for i, op in enumerate(expr.operands)
+            if i >= len(expr._parameters) or expr._parameters[i] not in ignore
+        ]
+    )

--- a/dask_expr/io/csv.py
+++ b/dask_expr/io/csv.py
@@ -1,16 +1,27 @@
 import functools
+import operator
 
+from dask_expr._util import _convert_to_list
 from dask_expr.io.io import BlockwiseIO, PartitionsFiltered
 
 
 class ReadCSV(PartitionsFiltered, BlockwiseIO):
-    _parameters = ["filename", "usecols", "header", "_partitions", "storage_options"]
+    _parameters = [
+        "filename",
+        "columns",
+        "header",
+        "_partitions",
+        "storage_options",
+        "_series",
+    ]
     _defaults = {
-        "usecols": None,
+        "columns": None,
         "header": "infer",
         "_partitions": None,
         "storage_options": None,
+        "_series": False,
     }
+    _absorb_projections = False
 
     @functools.cached_property
     def _ddf(self):
@@ -19,14 +30,28 @@ class ReadCSV(PartitionsFiltered, BlockwiseIO):
 
         return dd.read_csv(
             self.filename,
-            usecols=self.usecols,
+            usecols=_convert_to_list(self.operand("columns")),
             header=self.header,
             storage_options=self.storage_options,
         )
 
     @property
     def _meta(self):
-        return self._ddf._meta
+        meta = self._ddf._meta
+        if self.columns:
+            return meta[self.columns[0]] if self._series else meta[self.columns]
+        return meta
+
+    @functools.cached_property
+    def columns(self):
+        columns_operand = self.operand("columns")
+        if columns_operand is None:
+            try:
+                return list(self._ddf._meta.columns)
+            except AttributeError:
+                return []
+        else:
+            return _convert_to_list(columns_operand)
 
     def _divisions(self):
         return self._ddf.divisions
@@ -36,4 +61,6 @@ class ReadCSV(PartitionsFiltered, BlockwiseIO):
         return list(self._ddf.dask.to_dict().values())
 
     def _filtered_task(self, index: int):
+        if self._series:
+            return (operator.getitem, self._tasks[index], self.columns[0])
         return self._tasks[index]

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -5,8 +5,16 @@ import math
 
 from dask.dataframe.io.io import sorted_division_locations
 
-from dask_expr._expr import Blockwise, Expr, Lengths, Literal, PartitionsFiltered
+from dask_expr._expr import (
+    Blockwise,
+    Expr,
+    Lengths,
+    Literal,
+    PartitionsFiltered,
+    Projection,
+)
 from dask_expr._reductions import Len
+from dask_expr._util import _convert_to_list
 
 
 class IO(Expr):
@@ -39,19 +47,98 @@ class FromGraph(IO):
 
 
 class BlockwiseIO(Blockwise, IO):
-    pass
+    _absorb_projections = False
+
+    def _simplify_up(self, parent):
+        if self._absorb_projections and isinstance(parent, Projection):
+            # Column projection
+            parent_columns = parent.operand("columns")
+            substitutions = {"columns": _convert_to_list(parent_columns)}
+            if isinstance(parent_columns, (str, int)):
+                substitutions["_series"] = True
+            return self.substitute_parameters(substitutions)
+
+    def _combine_similar(self, root: Expr):
+        if self._absorb_projections:
+            # For ReadParquet, we can avoid redundant file-system
+            # access by aggregating multiple operations with different
+            # column projections into the same operation.
+            alike = self._find_similar_operations(root, ignore=["columns", "_series"])
+            if alike:
+                # We have other ReadParquet operations in the expression
+                # graph that can be combined with this one.
+
+                # Find the column-projection union needed to combine
+                # the qualified ReadParquet operations
+                columns_operand = self.operand("columns")
+                if columns_operand is None:
+                    columns_operand = self.columns
+                columns = set(columns_operand)
+                rps = [self] + alike
+                for rp in alike:
+                    rp_columns = rp.operand("columns")
+                    if rp_columns is None:
+                        rp_columns = rp.columns
+                    columns |= set(rp_columns)
+                columns = sorted(columns)
+
+                # Can bail if we are not changing columns or the "_series" operand
+                if columns_operand == columns and (
+                    len(columns) > 1 or not self._series
+                ):
+                    return
+
+                # Check if we have the operation we want elsewhere in the graph
+                for rp in rps:
+                    # if rp.operand("columns") == columns and not rp.operand("_series"):
+                    if rp.columns == columns and not rp.operand("_series"):
+                        return (
+                            rp[columns_operand[0]]
+                            if self._series
+                            else rp[columns_operand]
+                        )
+
+                # Create the "combined" ReadParquet operation
+                subs = {"columns": columns}
+                if self._series:
+                    subs["_series"] = False
+                new = self.substitute_parameters(subs)
+                return new[columns_operand[0]] if self._series else new[columns_operand]
+
+        return
 
 
 class FromPandas(PartitionsFiltered, BlockwiseIO):
     """The only way today to get a real dataframe"""
 
-    _parameters = ["frame", "npartitions", "sort", "_partitions"]
-    _defaults = {"npartitions": 1, "sort": True, "_partitions": None}
+    _parameters = ["frame", "npartitions", "sort", "columns", "_partitions", "_series"]
+    _defaults = {
+        "npartitions": 1,
+        "sort": True,
+        "columns": None,
+        "_partitions": None,
+        "_series": False,
+    }
     _pd_length_stats = None
+    _absorb_projections = True
 
     @property
     def _meta(self):
-        return self.frame.head(0)
+        meta = self.frame.head(0)
+        if self.columns:
+            return meta[self.columns[0]] if self._series else meta[self.columns]
+        return meta
+
+    @functools.cached_property
+    def columns(self):
+        columns_operand = self.operand("columns")
+        if columns_operand is None:
+            try:
+                return list(self.frame.columns)
+            except AttributeError:
+                return []
+        else:
+            return _convert_to_list(columns_operand)
 
     @functools.cached_property
     def _divisions_and_locations(self):
@@ -93,6 +180,9 @@ class FromPandas(PartitionsFiltered, BlockwiseIO):
             if _lengths:
                 return Literal(sum(_lengths))
 
+        if isinstance(parent, Projection):
+            return super()._simplify_up(parent)
+
     def _divisions(self):
         return self._divisions_and_locations[0]
 
@@ -101,7 +191,10 @@ class FromPandas(PartitionsFiltered, BlockwiseIO):
 
     def _filtered_task(self, index: int):
         start, stop = self._locations()[index : index + 2]
-        return self.frame.iloc[start:stop]
+        part = self.frame.iloc[start:stop]
+        if self.columns:
+            return part[self.columns[0]] if self._series else part[self.columns]
+        return part
 
     def __str__(self):
         return "df"

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -94,7 +94,8 @@ class BlockwiseIO(Blockwise, IO):
                         op_columns = op.columns
                     columns |= set(op_columns)
                 columns = sorted(columns)
-
+                if columns_operand is None:
+                    columns_operand = self.columns
                 # Can bail if we are not changing columns or the "_series" operand
                 if columns_operand == columns and (
                     len(columns) > 1 or not self._series

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import math
 
+from dask.dataframe.core import is_dataframe_like
 from dask.dataframe.io.io import sorted_division_locations
 
 from dask_expr._expr import (
@@ -50,7 +51,11 @@ class BlockwiseIO(Blockwise, IO):
     _absorb_projections = False
 
     def _simplify_up(self, parent):
-        if self._absorb_projections and isinstance(parent, Projection):
+        if (
+            self._absorb_projections
+            and isinstance(parent, Projection)
+            and is_dataframe_like(self._meta)
+        ):
             # Column projection
             parent_columns = parent.operand("columns")
             substitutions = {"columns": _convert_to_list(parent_columns)}

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -416,6 +416,7 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
         "_series": False,
     }
     _pq_length_stats = None
+    _absorb_projections = True
 
     @property
     def engine(self):
@@ -432,57 +433,13 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
         else:
             return _convert_to_list(columns_operand)
 
-    def _combine_similar(self, root: Expr):
-        # For ReadParquet, we can avoid redundant file-system
-        # access by aggregating multiple operations with different
-        # column projections into the same operation.
-        alike = self._find_similar_operations(root, ignore=["columns", "_series"])
-        if alike:
-            # We have other ReadParquet operations in the expression
-            # graph that can be combined with this one.
-
-            # Find the column-projection union needed to combine
-            # the qualified ReadParquet operations
-            columns = set()
-            rps = [self] + alike
-            for rp in rps:
-                if rp.operand("columns"):
-                    columns |= set(rp.operand("columns"))
-            columns = sorted(columns)
-
-            # Can bail if we are not changing columns or the "_series" operand
-            columns_operand = self.operand("columns")
-            if columns_operand == columns and (len(columns) > 1 or not self._series):
-                return
-
-            # Check if we have the operation we want elsewhere in the graph
-            for rp in rps:
-                if rp.operand("columns") == columns and not rp.operand("_series"):
-                    return (
-                        rp[columns_operand[0]] if self._series else rp[columns_operand]
-                    )
-
-            # Create the "combined" ReadParquet operation
-            subs = {"columns": columns}
-            if self._series:
-                subs["_series"] = False
-            new = self.substitute_parameters(subs)
-            return new[columns_operand[0]] if self._series else new[columns_operand]
-
-        return
-
     def _simplify_up(self, parent):
         if isinstance(parent, Index):
             # Column projection
             return self.substitute_parameters({"columns": [], "_series": False})
 
         if isinstance(parent, Projection):
-            # Column projection
-            parent_columns = parent.operand("columns")
-            substitutions = {"columns": _convert_to_list(parent_columns)}
-            if isinstance(parent_columns, (str, int)):
-                substitutions["_series"] = True
-            return self.substitute_parameters(substitutions)
+            return super()._simplify_up(parent)
 
         if isinstance(parent, Filter) and isinstance(
             parent.predicate, (LE, GE, LT, GT, EQ, NE, And, Or)

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -1190,8 +1190,8 @@ def test_filter_pushdown(df, pdf):
 
     pdf["z"] = 1
     df = from_pandas(pdf, npartitions=10)
-    df2 = df.dropna().replace(1, 5)
+    df2 = df.replace(1, 5)
     result = df2[df2.x > 5][["x", "y"]].optimize(fuse=False)
-    df_opt = df[["x", "y"]].simplify().dropna().replace(1, 5)
+    df_opt = df[["x", "y"]].simplify().replace(1, 5)
     expected = df_opt[df_opt.x > 5]
     assert result._name == expected._name

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -411,7 +411,10 @@ def test_rename_traverse_filter(df):
     assert str(result) == str(expected)
 
 
-def test_columns_traverse_filters(df):
+def test_columns_traverse_filters(pdf):
+    pdf = pdf.copy()
+    pdf["z"] = pdf["x"]
+    df = from_pandas(pdf, npartitions=10)
     result = df[df.x > 5].y.optimize(fuse=False)
     df_opt = df[["x", "y"]].simplify()
     expected = df_opt.y[df_opt.x > 5]

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -349,12 +349,12 @@ def test_blockwise_pandas_only(func, pdf, df):
 
 def test_simplify_add_suffix_add_prefix(df, pdf):
     result = df.add_prefix("2_")["2_x"].simplify()
-    expected = df[["x"]].add_prefix("2_")["2_x"]
+    expected = df[["x"]].simplify().add_prefix("2_")["2_x"]
     assert result._name == expected._name
     assert_eq(result, pdf.add_prefix("2_")["2_x"])
 
     result = df.add_suffix("_2")["x_2"].simplify()
-    expected = df[["x"]].add_suffix("_2")["x_2"]
+    expected = df[["x"]].simplify().add_suffix("_2")["x_2"]
     assert result._name == expected._name
     assert_eq(result, pdf.add_suffix("_2")["x_2"])
 
@@ -400,22 +400,23 @@ def test_combine_first_simplify(pdf):
 
     q = df.combine_first(df2)[["z", "y"]]
     result = q.simplify()
-    expected = df[["y"]].combine_first(df2[["z"]])[["z", "y"]]
+    expected = df[["y"]].simplify().combine_first(df2[["z"]])[["z", "y"]]
     assert result._name == expected._name
     assert_eq(result, pdf.combine_first(pdf2)[["z", "y"]])
 
 
 def test_rename_traverse_filter(df):
     result = df.rename(columns={"x": "xx"})[["xx"]].simplify()
-    expected = df[["x"]].rename(columns={"x": "xx"})
+    expected = df[["x"]].simplify().rename(columns={"x": "xx"})
     assert str(result) == str(expected)
 
 
 def test_columns_traverse_filters(df):
-    result = df[df.x > 5].y.simplify()
-    expected = df.y[df.x > 5]
+    result = df[df.x > 5].y.optimize(fuse=False)
+    df_opt = df[["x", "y"]].simplify()
+    expected = df_opt.y[df_opt.x > 5]
 
-    assert str(result) == str(expected)
+    assert result._name == expected._name
 
 
 def test_clip_traverse_filters(df):
@@ -538,7 +539,7 @@ def test_tail_repartition(df):
 def test_projection_stacking(df):
     result = df[["x", "y"]]["x"]
     optimized = result.simplify()
-    expected = df["x"].optimize()
+    expected = df["x"].simplify()
 
     assert optimized._name == expected._name
 
@@ -565,7 +566,7 @@ def test_remove_unnecessary_projections(df):
 
     result = (df[["x"]] + 1)[["x"]]
     optimized = result.simplify()
-    expected = df[["x"]] + 1
+    expected = df[["x"]].simplify() + 1
 
     assert optimized._name == expected._name
 
@@ -842,18 +843,18 @@ def test_len(df, pdf):
 def test_astype_simplify(df, pdf):
     q = df.astype({"x": "float64", "y": "float64"})["x"]
     result = q.simplify()
-    expected = df["x"].astype({"x": "float64"})
+    expected = df["x"].simplify().astype({"x": "float64"})
     assert result._name == expected._name
     assert_eq(q, pdf.astype({"x": "float64", "y": "float64"})["x"])
 
     q = df.astype({"y": "float64"})["x"]
     result = q.simplify()
-    expected = df["x"]
+    expected = df["x"].simplify()
     assert result._name == expected._name
 
     q = df.astype("float64")["x"]
     result = q.simplify()
-    expected = df["x"].astype("float64")
+    expected = df["x"].simplify().astype("float64")
     assert result._name == expected._name
 
 
@@ -916,7 +917,7 @@ def test_dropna_simplify(pdf, subset):
     df = from_pandas(pdf)
     q = df.dropna(subset=subset)["y"]
     result = q.simplify()
-    expected = df[["x", "y"]].dropna(subset=subset)["y"]
+    expected = df[["x", "y"]].simplify().dropna(subset=subset)["y"]
     assert result._name == expected._name
     assert_eq(q, pdf.dropna(subset=subset)["y"])
 
@@ -945,14 +946,14 @@ def test_dir(df):
 def test_simplify_up_blockwise(df, pdf, func, args, indexer):
     q = getattr(df, func)(*args)[indexer]
     result = q.simplify()
-    expected = getattr(df[indexer], func)(*args)
+    expected = getattr(df[indexer].simplify(), func)(*args)
     assert result._name == expected._name
 
     assert_eq(q, getattr(pdf, func)(*args)[indexer])
 
     q = getattr(df, func)(*args)[["x", "y"]]
     result = q.simplify()
-    expected = getattr(df, func)(*args)
+    expected = getattr(df.simplify(), func)(*args)
     assert result._name == expected._name
 
 
@@ -1094,7 +1095,7 @@ def test_astype_categories(df):
 def test_drop_simplify(df):
     q = df.drop(columns=["x"])[["y"]]
     result = q.simplify()
-    expected = df[["y"]]
+    expected = df[["y"]].simplify()
     assert result._name == expected._name
 
 
@@ -1110,8 +1111,7 @@ def test_op_align():
 
 def test_can_co_align(df, pdf):
     q = (df.x + df.y).optimize(fuse=False)
-    expected = df.x + df.y
-    assert q._name == expected._name
+    assert_eq(q, pdf.x + pdf.y)
 
     pdf["z"] = 100
     df2 = from_pandas(pdf, npartitions=df.npartitions * 2)
@@ -1150,7 +1150,8 @@ def test_filter_pushdown(df, pdf):
 
     pdf["z"] = 1
     df = from_pandas(pdf, npartitions=10)
-    df = df.dropna().replace(1, 5)
-    result = df[df.x > 5][["x", "y"]].optimize(fuse=False)
-    expected = df[["x", "y"]][df.x > 5]
+    df2 = df.dropna().replace(1, 5)
+    result = df2[df2.x > 5][["x", "y"]].optimize(fuse=False)
+    df_opt = df[["x", "y"]].simplify().dropna().replace(1, 5)
+    expected = df_opt[df_opt.x > 5]
     assert result._name == expected._name

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -65,7 +65,7 @@ def test_explode_simplify(pdf):
     df = from_pandas(pdf)
     q = df.explode(column="x")["y"]
     result = optimize(q, fuse=False)
-    expected = df[["x", "y"]].explode(column="x")["y"]
+    expected = optimize(df[["x", "y"]], fuse=False).explode(column="x")["y"]
     assert result._name == expected._name
 
 
@@ -538,7 +538,7 @@ def test_tail_repartition(df):
 def test_projection_stacking(df):
     result = df[["x", "y"]]["x"]
     optimized = result.simplify()
-    expected = df["x"]
+    expected = df["x"].optimize()
 
     assert optimized._name == expected._name
 

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -400,7 +400,7 @@ def test_combine_first_simplify(pdf):
 
     q = df.combine_first(df2)[["z", "y"]]
     result = q.simplify()
-    expected = df[["y"]].simplify().combine_first(df2[["z"]])[["z", "y"]]
+    expected = df[["y"]].simplify().combine_first(df2[["z"]].simplify())[["z", "y"]]
     assert result._name == expected._name
     assert_eq(result, pdf.combine_first(pdf2)[["z", "y"]])
 
@@ -421,7 +421,7 @@ def test_columns_traverse_filters(df):
 
 def test_clip_traverse_filters(df):
     result = df.clip(lower=10).y.simplify()
-    expected = df.y.clip(lower=10)
+    expected = df.y.simplify().clip(lower=10)
 
     assert result._name == expected._name
 
@@ -432,7 +432,7 @@ def test_clip_traverse_filters(df):
 
     arg = df.clip(lower=10)[["x"]]
     result = arg.simplify()
-    expected = df[["x"]].clip(lower=10)
+    expected = df[["x"]].simplify().clip(lower=10)
 
     assert result._name == expected._name
 
@@ -443,7 +443,7 @@ def test_drop_duplicates_subset_simplify(pdf, subset, projection):
     pdf["zz"] = 1
     df = from_pandas(pdf)
     result = df.drop_duplicates(subset=subset)[projection].simplify()
-    expected = df[["x", "zz"]].drop_duplicates(subset=subset)[projection]
+    expected = df[["x", "zz"]].simplify().drop_duplicates(subset=subset)[projection]
 
     assert str(result) == str(expected)
 

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -146,6 +146,7 @@ def test_set_index(df, pdf, upsample):
 
 def test_set_index_sorted(pdf):
     pdf = pdf.sort_values(by="y", ignore_index=True)
+    pdf["z"] = pdf["x"]
     df = from_pandas(pdf, npartitions=10)
     q = df.set_index("y", sorted=True)
     assert_eq(q, pdf.set_index("y"))
@@ -163,6 +164,7 @@ def test_set_index_sorted(pdf):
 
 def test_set_index_pre_sorted(pdf):
     pdf = pdf.sort_values(by="y", ignore_index=True)
+    pdf["z"] = pdf["x"]
     df = from_pandas(pdf, npartitions=10)
     q = df.set_index("y")
     assert_eq(q, pdf.set_index("y"))


### PR DESCRIPTION
Follow up to #245, where I noticed that we were not quite capturing optimal column projection behavior for expressions originating from `FromPandas`. More specifically, since `FromPandas` does not "absorb" a `Projection` into it's own `"columns"` operand, it becomes difficult to produce a "combined" column projection at the optimal position in the expression graph.

For example:

```python
import dask_expr as dx
import pandas as pd

pdf = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6], "y": [4, 5, 8, 6, 1, 4], "z": 1})
df = dx.from_pandas(pdf, npartitions=3)

df = df.dropna().replace(1, 5)
df = df[df.x > 3][["x", "y"]]

df.optimize(fuse=False).pprint()
```

**Before this PR**:

In `main`, we currently perform `DropnaFrame` and `Replace` on **all** columns of `pdf`, even though we know that we can drop column `"z"` immediately.

```
Filter:
  Projection: columns=['x', 'y']
    Replace: to_replace=1 value=5
      DropnaFrame:
        FromPandas: frame='<pandas>' npartitions=3
  GT: right=3
    Projection: columns='x'
      Replace: to_replace=1 value=5
        DropnaFrame:
          FromPandas: frame='<pandas>' npartitions=3
```

**After this PR**:

By allowing `FromPandas` (and `ReadCSV`) to absorb column projections, we can produce much more optimal behavior.

```
Filter:
  Replace: to_replace=1 value=5
    DropnaFrame:
      FromPandas: frame='<pandas>' npartitions=3 columns=['x', 'y']
  GT: right=3
    Projection: columns='x'
      Replace: to_replace=1 value=5
        DropnaFrame:
          FromPandas: frame='<pandas>' npartitions=3 columns=['x', 'y']
```