### PR TITLE
[WIP] Support ``split_out>1`` and ``sort=True`` for aggregations

### DIFF
--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -523,11 +523,15 @@ class GroupBy:
         numeric_kwargs = self._numeric_only_kwargs(numeric_only)
         return self._single_agg(Max, **kwargs, **numeric_kwargs)
 
-    def first(self, numeric_only=False, **kwargs):
+    def first(self, numeric_only=False, sort=None, **kwargs):
+        if sort:
+            raise NotImplementedError()
         numeric_kwargs = self._numeric_only_kwargs(numeric_only)
         return self._single_agg(First, **kwargs, **numeric_kwargs)
 
-    def last(self, numeric_only=False, **kwargs):
+    def last(self, numeric_only=False, sort=None, **kwargs):
+        if sort:
+            raise NotImplementedError()
         numeric_kwargs = self._numeric_only_kwargs(numeric_only)
         return self._single_agg(Last, **kwargs, **numeric_kwargs)
 

--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -69,6 +69,7 @@ class SingleAggregation(ApplyConcatApply):
         "dropna",
         "chunk_kwargs",
         "aggregate_kwargs",
+        "split_out",
         "_slice",
     ]
     _defaults = {
@@ -76,11 +77,16 @@ class SingleAggregation(ApplyConcatApply):
         "dropna": None,
         "chunk_kwargs": None,
         "aggregate_kwargs": None,
+        "split_out": 1,
         "_slice": None,
     }
 
     groupby_chunk = None
     groupby_aggregate = None
+
+    @property
+    def split_by(self):
+        return self.by
 
     @classmethod
     def chunk(cls, df, by=None, **kwargs):
@@ -159,11 +165,13 @@ class GroupbyAggregation(ApplyConcatApply):
         "observed",
         "dropna",
         "split_every",
+        "split_out",
     ]
     _defaults = {
         "observed": None,
         "dropna": None,
         "split_every": 8,
+        "split_out": 1,
     }
 
     @functools.cached_property
@@ -435,8 +443,8 @@ class GroupBy:
     def _single_agg(
         self, expr_cls, split_out=1, chunk_kwargs=None, aggregate_kwargs=None
     ):
-        if split_out > 1:
-            raise NotImplementedError("split_out>1 not yet supported")
+        # if split_out > 1:
+        #    raise NotImplementedError("split_out>1 not yet supported")
         return new_collection(
             expr_cls(
                 self.obj.expr,
@@ -445,17 +453,19 @@ class GroupBy:
                 self.dropna,
                 chunk_kwargs=chunk_kwargs,
                 aggregate_kwargs=aggregate_kwargs,
+                split_out=split_out,
                 _slice=self._slice,
             )
         )
 
     def _aca_agg(self, expr_cls, split_out=1, **kwargs):
-        if split_out > 1:
-            raise NotImplementedError("split_out>1 not yet supported")
+        # if split_out > 1:
+        #    raise NotImplementedError("split_out>1 not yet supported")
         x = new_collection(
             expr_cls(
                 self.obj.expr,
                 by=self.by,
+                split_out=split_out,
                 **kwargs,
                 # TODO: Add observed and dropna when supported in dask/dask
             )
@@ -530,8 +540,8 @@ class GroupBy:
         if arg is None:
             raise NotImplementedError("arg=None not supported")
 
-        if split_out > 1:
-            raise NotImplementedError("split_out>1 not yet supported")
+        # if split_out > 1:
+        #    raise NotImplementedError("split_out>1 not yet supported")
 
         return new_collection(
             GroupbyAggregation(
@@ -541,6 +551,7 @@ class GroupBy:
                 self.observed,
                 self.dropna,
                 split_every,
+                split_out,
             )
         )
 

--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -620,7 +620,7 @@ class AssignPartitioningIndex(Blockwise):
 
 class BaseSetIndexSortValues(Expr):
     def _divisions(self):
-        if self.user_divisions is not None:
+        if getattr(self, "user_divisions", None) is not None:
             return self.user_divisions
         divisions, mins, maxes, presorted = _calculate_divisions(
             self.frame,

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -52,10 +52,10 @@ def test_groupby_no_numeric_only(pdf, func):
     assert_eq(agg, expect)
 
 
-def test_groupby_mean_slice(pdf, df):
+@pytest.mark.parametrize("split_out", [1, 2])
+def test_groupby_mean_slice(pdf, df, split_out):
     g = df.groupby("x")
-    agg = g.y.mean()
-
+    agg = g.y.mean(split_out=split_out)
     expect = pdf.groupby("x").y.mean()
     assert_eq(agg, expect)
 

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -70,12 +70,25 @@ def test_groupby_no_numeric_only(pdf, func):
     assert_eq(agg, expect)
 
 
-@pytest.mark.parametrize("split_out", [1, 2])
-def test_groupby_mean_slice(pdf, df, split_out):
+def test_groupby_mean_slice(pdf, df):
     g = df.groupby("x")
-    agg = g.y.mean(split_out=split_out)
+    agg = g.y.mean()
+
     expect = pdf.groupby("x").y.mean()
     assert_eq(agg, expect)
+
+
+@pytest.mark.parametrize(
+    "api", ["sum", "mean", "min", "max", "prod", "first", "last", "var", "std"]
+)
+@pytest.mark.parametrize("sort", [True, False])
+@pytest.mark.parametrize("split_out", [1, 2])
+def test_groupby_single_agg_split_out(pdf, df, api, sort, split_out):
+    g = df.groupby("x", sort=sort)
+    agg = getattr(g, api)(split_out=split_out)
+
+    expect = getattr(pdf.groupby("x", sort=sort), api)()
+    assert_eq(agg, expect, sort_results=not sort)
 
 
 def test_groupby_series(pdf, df):
@@ -108,6 +121,27 @@ def test_groupby_agg(pdf, df, spec):
 
     expect = pdf.groupby("x").agg(spec)
     assert_eq(agg, expect)
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {"x": "count"},
+        {"x": ["count"]},
+        {"x": ["count"], "y": "mean"},
+        {"x": ["sum", "mean"]},
+        ["min", "mean"],
+        "sum",
+    ],
+)
+@pytest.mark.parametrize("sort", [True, False])
+@pytest.mark.parametrize("split_out", [1, 2])
+def test_groupby_agg_split_out(pdf, df, spec, sort, split_out):
+    g = df.groupby("x", sort=sort)
+    agg = g.agg(spec, split_out=split_out)
+
+    expect = pdf.groupby("x", sort=sort).agg(spec)
+    assert_eq(agg, expect, sort_results=not sort)
 
 
 def test_groupby_getitem_agg(pdf, df):

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -78,9 +78,7 @@ def test_groupby_mean_slice(pdf, df):
     assert_eq(agg, expect)
 
 
-@pytest.mark.parametrize(
-    "api", ["sum", "mean", "min", "max", "prod", "first", "last", "var", "std"]
-)
+@pytest.mark.parametrize("api", ["sum", "mean", "min", "max", "prod", "var", "std"])
 @pytest.mark.parametrize("sort", [True, False])
 @pytest.mark.parametrize("split_out", [1, 2])
 def test_groupby_single_agg_split_out(pdf, df, api, sort, split_out):


### PR DESCRIPTION
Introduces a shuffle-based reduction algorithm to support ``split_out>1`` and ``sort=True``. 

(**Note**: Not sure if this is "ready" for eyes, but I wanted to push it somewhere visible as early as possible.)