### PR TITLE
Add ``_meta_nonempty`` to play nice with dask/dask

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -114,6 +114,10 @@ class FrameBase(DaskMethodsMixin):
     def _meta(self):
         return self.expr._meta
 
+    @functools.cached_property
+    def _meta_nonempty(self):
+        return meta_nonempty(self._meta)
+
     @property
     def size(self):
         return new_collection(self.expr.size)


### PR DESCRIPTION
I think we should add this for now to play nice with dask/dask. ``to_parquet`` needs this for example