### PR TITLE
Remove automatic seed value

### DIFF
--- a/dask_expr/datasets.py
+++ b/dask_expr/datasets.py
@@ -221,8 +221,5 @@ def timeseries(
     if dtypes is None:
         dtypes = {"name": "string", "id": int, "x": float, "y": float}
 
-    if seed is None:
-        seed = np.random.randint(2e9)
-
     expr = Timeseries(start, end, dtypes, freq, partition_freq, seed, kwargs)
     return new_collection(expr)

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -709,7 +709,7 @@ def test_tree_repr(fuse):
     s = from_pandas(lib.Series(range(10))).expr.tree_repr()
     assert ("<pandas>" in s) or ("<series>" in s)
 
-    df = timeseries()
+    df = timeseries(seed=1)
     expr = ((df.x + 1).sum(skipna=False) + df.y.mean()).expr
 
     # Check result before optimization


### PR DESCRIPTION
Having a seed still creates a relatively large graph which makes benchmarks against dask/dask partially meaningless