### PR TITLE
Fix empty column projection in ``FromPandas``

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1614,9 +1614,6 @@ class Projection(Elemwise):
         if (
             str(self.frame.columns) == str(self.columns)
             and self._meta.ndim == self.frame._meta.ndim
-            and not (
-                isinstance(self.frame, BlockwiseIO) and self.frame._absorb_projections
-            )
         ):
             # TODO: we should get more precise around Expr.columns types
             return self.frame

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -138,7 +138,7 @@ class FromPandas(PartitionsFiltered, BlockwiseIO):
     @property
     def _meta(self):
         meta = self.frame.head(0)
-        if self.columns:
+        if self.columns is not None:
             return meta[self.columns[0]] if self._series else meta[self.columns]
         return meta
 


### PR DESCRIPTION
Addresses [this code-review comment](https://github.com/dask-contrib/dask-expr/pull/247/files#r1280308640) from #247, which exposed a bug for the case that we absorb an empty column projection into `FromPandas`.

**Notes**: Simply removing the `_absorb_projections` criteria exposed an infinite-recursion bug in `test_fusion.py::test_optimize_fusion_many` which all boiled down to the `.columns` attribute being incorrect for some expressions in the case that there is an empty column projection in `FromPandas`.

