### PR TITLE
Reduce size of `Timeseries` task graph

### DIFF
--- a/dask_expr/tests/test_datasets.py
+++ b/dask_expr/tests/test_datasets.py
@@ -1,3 +1,6 @@
+import pickle
+import sys
+
 import pytest
 from dask.dataframe.utils import assert_eq
 
@@ -94,3 +97,9 @@ def test_combine_similar(tmpdir):
 def test_timeseries_deterministic_head(seed):
     df = timeseries(end="2000-01-02", seed=seed)
     assert_eq(df.head(), df.head())
+
+
+def test_timeseries_gaph_size():
+    df = timeseries(end="2000-01-03", seed=42)
+    graph_size = sys.getsizeof(pickle.dumps(df.dask))
+    assert graph_size < 1024

--- a/dask_expr/tests/test_datasets.py
+++ b/dask_expr/tests/test_datasets.py
@@ -95,11 +95,20 @@ def test_combine_similar(tmpdir):
 
 @pytest.mark.parametrize("seed", [42, None])
 def test_timeseries_deterministic_head(seed):
+    # Make sure our `random_state` code gives
+    # us deterministic results
     df = timeseries(end="2000-01-02", seed=seed)
     assert_eq(df.head(), df.head())
+    assert_eq(df["x"].head(), df.head()["x"])
+    assert_eq(df.head()["x"], df["x"].partitions[0].compute().head())
 
 
 def test_timeseries_gaph_size():
+    # Check that our graph size is reasonable
     df = timeseries(end="2000-01-03", seed=42)
     graph_size = sys.getsizeof(pickle.dumps(df.dask))
+    # This criteria is somewhat arbitrary. The
+    # original `random_state` code was producing
+    # ~5KB here. So, we know the size should
+    # always remain smaller than that.
     assert graph_size < 1024

--- a/dask_expr/tests/test_datasets.py
+++ b/dask_expr/tests/test_datasets.py
@@ -88,3 +88,9 @@ def test_combine_similar(tmpdir):
     assert len(timeseries_nodes) == 2
     with pytest.raises(AssertionError):
         assert_eq(df + df2, 2 * df)
+
+
+@pytest.mark.parametrize("seed", [42, None])
+def test_timeseries_deterministic_head(seed):
+    df = timeseries(end="2000-01-02", seed=seed)
+    assert_eq(df.head(), df.head())


### PR DESCRIPTION
Possible alternative to #263

While reviewing #263, I realized we were going a bit "overboard" in `Timeseries.random_state`. More specifically, we were generating/storing `624 * len(dtypes)` 32-bit integers for every task. Given that the `timeseries` utility is generally meant for demonstration, testing and benchmarking, I don't see any reason to generate/store more than `len(dtypes)` integers for each task.

This PR reduces the number of random integers we store for each task by a factor of 624 (therefore, significantly reducing the size of the graph).