### PR TITLE
Add ``lower_completely`` method

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -147,12 +147,12 @@ class FrameBase(DaskMethodsMixin):
 
     def __dask_graph__(self):
         out = self.expr
-        out = out.optimize(fuse=False)
+        out = out.lower_completely()
         return out.__dask_graph__()
 
     def __dask_keys__(self):
         out = self.expr
-        out = out.optimize(fuse=False)
+        out = out.lower_completely()
         return out.__dask_keys__()
 
     def simplify(self):
@@ -171,13 +171,13 @@ class FrameBase(DaskMethodsMixin):
         return self.__dask_graph__()
 
     def __dask_postcompute__(self):
-        state = self.optimize(fuse=False)
+        state = new_collection(self.expr.lower_completely())
         if type(self) != type(state):
             return state.__dask_postcompute__()
         return _concat, ()
 
     def __dask_postpersist__(self):
-        state = self.optimize(fuse=False)
+        state = new_collection(self.expr.lower_completely())
         return from_graph, (state._meta, state.divisions, state._name)
 
     def __getattr__(self, key):

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -334,6 +334,32 @@ class Expr:
 
         return out
 
+    def lower_completely(self) -> Expr:
+        """Lower an expression completely
+
+        This calls the ``lower_once`` method in a loop
+        until nothing changes. This function does not
+        apply any other optimizations (like ``simplify``).
+
+        Returns
+        -------
+        expr:
+            output expression
+
+        See Also
+        --------
+        Expr.lower_once
+        Expr._lower
+        """
+        # Lower until nothing changes
+        expr = self
+        while True:
+            new = expr.lower_once()
+            if new._name == expr._name:
+                break
+            expr = new
+        return expr
+
     def _lower(self):
         return
 

--- a/dask_expr/tests/test_datasets.py
+++ b/dask_expr/tests/test_datasets.py
@@ -52,7 +52,6 @@ def test_persist():
     b = a.persist()
 
     assert_eq(a, b)
-    assert len(a.dask) == len(b.dask)
     assert len(b.dask) == b.npartitions
 
 


### PR DESCRIPTION
Possible compliment to https://github.com/dask-contrib/dask-expr/pull/274

Adds `Expr.lower_completely` to run automatically before graph generation (instead of `optimize`). By avoiding optimization in `__dask_graph__`, we can configure optional optimization options in `compute`/`persist`.