### PR TITLE
Avoid pushing Projections through HashP2P

### DIFF
--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -337,6 +337,9 @@ class HashJoinP2P(Merge, PartitionsFiltered):
             )
         return dsk
 
+    def _simplify_up(self, parent):
+        return
+
 
 class BlockwiseMerge(Merge, Blockwise):
     """Merge two dataframes with aligned partitions


### PR DESCRIPTION
This causes problems, so we shouldn't push them through here, that should happen before we lower