### PR TITLE
[RFC] Cache Expr objects

### DIFF
--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -1212,3 +1212,11 @@ def test_shape(df, pdf):
 
 def test_size(df, pdf):
     assert_eq(df.size, pdf.size)
+
+
+def test_object_caching(df):
+    a = df + 1
+    b = df + 1
+    assert a._expr is b._expr
+    assert a._meta is b._meta
+    del a, b


### PR DESCRIPTION
Much of our overhead comes from doing computational work in other libraries (pandas, arrow, ...) that could be cached.  We do cache a lot of stuff today, but we store these caches on the object itself.  When we then recreate objects (for example in optimization) then we lose those caches.

One solution here is to cache the objects themselves, so that `Op(...) is Op(...)`.  This technique is a bit magical, but is used in other projects like SymPy where it has had good performance impacts (although they use it because they make many more very small objects).

Maybe this isn't relevant for us.  Ideally we wouldn't recreate objects often in optimization (this is why we return the original object if arguments match).  But maybe it's hard to be careful.  If so, this might provide a bit of a sledgehammer approach.

THis isn't done yet, in particular there are open questions about non-hashable inputs like pandas dataframes.  Hopefully it is a useful proof of concept.