### PR TITLE
Fix bug in sort_values in distributed setting

### DIFF
--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -907,18 +907,20 @@ class SortIndexBlockwise(Blockwise):
     _is_length_preserving = True
 
 
-def sort_function(self, *args, **kwargs):
-    sort_func = kwargs.pop("sort_function")
-    sort_kwargs = kwargs.pop("sort_kwargs")
-    return sort_func(*args, **kwargs, **sort_kwargs)
-
-
 class SortValuesBlockwise(Blockwise):
     _projection_passthrough = False
     _parameters = ["frame", "sort_function", "sort_kwargs"]
-    operation = sort_function
     _keyword_only = ["sort_function", "sort_kwargs"]
     _is_length_preserving = True
+
+    def operation(self, *args, **kwargs):
+        sort_func = kwargs.pop("sort_function")
+        sort_kwargs = kwargs.pop("sort_kwargs")
+        return sort_func(*args, **kwargs, **sort_kwargs)
+
+    @functools.cached_property
+    def _meta(self):
+        return self.frame._meta
 
 
 class SetIndexBlockwise(Blockwise):


### PR DESCRIPTION
Our await logic doesn't play nicely with the intermediate computes, hence the different test logic here. dask/dask suffers the same issue