### PR TITLE
Implement combine_similar for merge

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -416,6 +416,40 @@ class Expr:
     def _combine_similar(self, root: Expr):
         return
 
+    def _remove_operations(self, frame, remove_ops, skip_ops=None):
+        """Searches for operations that we have to push up again to avoid
+        the duplication of branches that are doing the same.
+
+        Parameters
+        ----------
+        frame: Expression that we will search.
+        remove_ops: Ops that we will remove to push up again.
+        skip_ops: Ops that were introduced and that we want to ignore.
+
+        Returns
+        -------
+        tuple of the new expression and the operations that we removed.
+        """
+
+        operations, ops_to_push_up = [], []
+        frame_base = frame
+        combined_ops = remove_ops if skip_ops is None else remove_ops + skip_ops
+        while isinstance(frame, combined_ops):
+            # Have to respect ops that were injected while lowering or filters
+            if isinstance(frame, remove_ops):
+                ops_to_push_up.append(frame.operands[1])
+            else:
+                operations.append((type(frame), frame.operands[1:]))
+            frame = frame.frame
+
+        if len(ops_to_push_up) > 0:
+            # Remove the projections but build the remaining things back up
+            for op_type, operands in reversed(operations):
+                frame = op_type(frame, *operands)
+            return frame, ops_to_push_up
+        else:
+            return frame_base, ops_to_push_up
+
     def optimize(self, **kwargs):
         return optimize(self, **kwargs)
 
@@ -1053,19 +1087,17 @@ class Blockwise(Expr):
             or self._filter_passthrough
             and isinstance(self.frame, Filter)
         ):
-            frame, operations = self.frame, []
             # We have to go back until we reach an operation that was not pushed down
-            while isinstance(frame, (Filter, Projection)):
-                operations.append(frame.operands[1])
-                frame = frame.frame
-            else:
-                try:
-                    common = type(self)(frame, *self.operands[1:])
-                except ValueError:
-                    # May have encountered a problem with `_required_attribute`.
-                    # (There is no guarentee that the same method will exist for
-                    # both a Series and DataFrame)
-                    return None
+            frame, operations = self._remove_operations(
+                self.frame, (Filter, Projection)
+            )
+            try:
+                common = type(self)(frame, *self.operands[1:])
+            except ValueError:
+                # May have encountered a problem with `_required_attribute`.
+                # (There is no guarentee that the same method will exist for
+                # both a Series and DataFrame)
+                return None
             push_up_op = False
             for op in self._find_similar_operations(root, ignore=self._parameters):
                 if (

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -256,7 +256,6 @@ class Merge(Expr):
 
     def _combine_similar(self, root: Expr):
         # Push projections back up to avoid performing the same merge multiple times
-        # return
 
         def _remove_projections(frame):
             operations, columns = [], []

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -304,9 +304,10 @@ class Merge(Expr):
                 break
 
         if push_up_op:
-            columns_left += [col for col in columns_right if col not in columns_left]
-            if sorted(common.columns) != sorted(columns_left):
-                common = common[columns_left]
+            columns = columns_left.copy()
+            columns += [col for col in columns_right if col not in columns_left]
+            if sorted(common.columns) != sorted(columns):
+                common = common[columns]
             common = common._simplify_down() or common
             return common
 

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -104,7 +104,7 @@ class Merge(Expr):
         #  2. Add multi-partition broadcast merge
         #  3. Add/leverage partition statistics
 
-        # # Check for "trivial" broadcast (single partition)
+        # Check for "trivial" broadcast (single partition)
         npartitions = max(left.npartitions, right.npartitions)
         if (
             npartitions == 1

--- a/dask_expr/tests/test_merge.py
+++ b/dask_expr/tests/test_merge.py
@@ -176,3 +176,32 @@ def test_merge_optimize_subset_strings():
     exp = df[["aaa"]].merge(df2[["aaa"]], on="aaa").optimize(fuse=False)
     assert query._name == exp._name
     assert_eq(query, pdf.merge(pdf2, on="aaa")[["aaa"]])
+
+
+def test_merge_combine_similar():
+    pdf = lib.DataFrame(
+        {
+            "a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            "b": 1,
+            "c": 1,
+            "d": 1,
+            "e": 1,
+            "f": 1,
+        }
+    )
+    pdf2 = lib.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "x": 1})
+
+    df = from_pandas(pdf, npartitions=2)
+    df2 = from_pandas(pdf2, npartitions=3)
+
+    query = df.merge(df2)
+    query["new"] = query.b + query.c
+    query = query.groupby(["a", "e"]).new.sum()
+    assert (
+        len(query.optimize().__dask_graph__()) <= 25
+    )  # 45 is the non-combined version
+
+    expected = pdf.merge(pdf2)
+    expected["new"] = expected.b + expected.c
+    expected = expected.groupby(["a", "e"]).new.sum()
+    assert_eq(query, expected)

--- a/dask_expr/tests/test_merge.py
+++ b/dask_expr/tests/test_merge.py
@@ -196,12 +196,12 @@ def test_merge_combine_similar():
 
     query = df.merge(df2)
     query["new"] = query.b + query.c
-    query = query.groupby(["a", "e"]).new.sum()
+    query = query.groupby(["a", "e", "x"]).new.sum()
     assert (
         len(query.optimize().__dask_graph__()) <= 25
     )  # 45 is the non-combined version
 
     expected = pdf.merge(pdf2)
     expected["new"] = expected.b + expected.c
-    expected = expected.groupby(["a", "e"]).new.sum()
+    expected = expected.groupby(["a", "e", "x"]).new.sum()
     assert_eq(query, expected)


### PR DESCRIPTION
That was trickier than expected. We want to pull projections after the merge operation if we can avoid merging multiple times through this. I am not touching filters here since we are not pushing them through either, that might be something for later (but pushing filter through merges can be tricky). 

We performed the same 2 merge operation 3 times in one of the tpch queries, this PR cuts the runtime by 70%