### PR TITLE
Fix equality comparison of scalars with expressions

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -108,6 +108,11 @@ class FrameBase(DaskMethodsMixin):
     def __init__(self, expr):
         self._expr = expr
 
+    def __eq__(self, other):
+        if isinstance(other, FrameBase):
+            other = other.expr
+        return new_collection(expr.EQ(self.expr, other))
+
     @property
     def expr(self) -> expr.Expr:
         return self._expr
@@ -569,7 +574,6 @@ for op in [
     "__rle__",
     "__ge__",
     "__rge__",
-    "__eq__",
     "__ne__",
     "__and__",
     "__rand__",

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -545,7 +545,9 @@ class Expr:
         return GE(other, self)
 
     def __eq__(self, other):
-        return EQ(self, other)
+        if isinstance(other, Expr):
+            return self._name == other._name
+        return False
 
     def __ne__(self, other):
         return NE(self, other)

--- a/dask_expr/_util.py
+++ b/dask_expr/_util.py
@@ -26,7 +26,14 @@ def _convert_to_list(column) -> list | None:
 
 def is_scalar(x):
     # np.isscalar does not work for some pandas scalars, for example pd.NA
-    return not (isinstance(x, Sequence) or hasattr(x, "dtype")) or isinstance(x, str)
+    if isinstance(x, Sequence) or hasattr(x, "dtype"):
+        return True
+    if isinstance(x, (str, int)):
+        return True
+
+    from dask_expr._expr import Expr
+
+    return not isinstance(x, Expr)
 
 
 @normalize_token.register(LambdaType)

--- a/dask_expr/_util.py
+++ b/dask_expr/_util.py
@@ -26,8 +26,8 @@ def _convert_to_list(column) -> list | None:
 
 def is_scalar(x):
     # np.isscalar does not work for some pandas scalars, for example pd.NA
-    if isinstance(x, Sequence) or hasattr(x, "dtype"):
-        return True
+    if isinstance(x, Sequence) and not isinstance(x, str) or hasattr(x, "dtype"):
+        return False
     if isinstance(x, (str, int)):
         return True
 

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -10,7 +10,7 @@ from dask.dataframe._compat import PANDAS_GE_210
 from dask.dataframe.utils import UNKNOWN_CATEGORIES, assert_eq
 from dask.utils import M
 
-from dask_expr import expr, from_pandas, optimize
+from dask_expr import expr, from_pandas, is_scalar, optimize
 from dask_expr._expr import are_co_aligned
 from dask_expr._reductions import Len
 from dask_expr.datasets import timeseries
@@ -1221,3 +1221,8 @@ def test_drop_duplicates_groupby(pdf):
     query = df.groupby("y").z.count()
     expected = pdf.drop_duplicates(subset="x").groupby("y").z.count()
     assert_eq(query, expected)
+
+
+def test_expr_is_scalar(df):
+    assert not is_scalar(df.expr)
+    assert not df.expr.x in df.expr.columns  # noqa: E713

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -389,9 +389,9 @@ def test_repr(df):
     assert "+ 1" in repr(df + 1)
 
     s = (df["x"] + 1).sum(skipna=False).expr
-    assert '["x"]' in s or "['x']" in s
-    assert "+ 1" in s
-    assert "sum(skipna=False)" in s
+    assert '["x"]' in str(s) or "['x']" in str(s)
+    assert "+ 1" in str(s)
+    assert "sum(skipna=False)" in str(s)
 
 
 @xfail_gpu("combine_first not supported by cudf")


### PR DESCRIPTION
cc @mrocklin 

This is one potential approach that we could. We would have to remove every other binary op from Expr as well, since, ``2 < df.expr`` is still True.

The alternative would be to raise for ``bool(Expr)``, which might make more sense, although we couldn't use Expressions in Sets or as dictionary keys anymore. ``bool(DaskDataFrame)`` raises as well

