### PR TITLE
Remove predicate pushdown from read_parquet

### DIFF
--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -37,7 +37,6 @@ from dask_expr._expr import (
     And,
     Blockwise,
     Expr,
-    Filter,
     Index,
     Lengths,
     Literal,
@@ -456,16 +455,6 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
 
         if isinstance(parent, Projection):
             return super()._simplify_up(parent)
-
-        if isinstance(parent, Filter) and isinstance(
-            parent.predicate, (LE, GE, LT, GT, EQ, NE, And, Or)
-        ):
-            # Predicate pushdown
-            filters = _DNF.extract_pq_filters(self, parent.predicate)
-            if filters:
-                kwargs = dict(zip(self._parameters, self.operands))
-                kwargs["filters"] = filters.combine(kwargs["filters"]).to_list_tuple()
-                return ReadParquet(**kwargs)
 
         if isinstance(parent, Lengths):
             _lengths = self._get_lengths()

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -85,6 +85,7 @@ def test_io_fusion(tmpdir, fmt):
     assert_eq(df2, df[["a", "b"]] + 1)
 
 
+@pytest.mark.skip()
 def test_predicate_pushdown(tmpdir):
     original = lib.DataFrame(
         {
@@ -112,6 +113,7 @@ def test_predicate_pushdown(tmpdir):
     assert (y_result == 4).all()
 
 
+@pytest.mark.skip()
 def test_predicate_pushdown_compound(tmpdir):
     pdf = lib.DataFrame(
         {


### PR DESCRIPTION
Removing this temporarily speeds up our workflows by a lot, here is a tpch run: https://github.com/coiled/benchmarks/actions/runs/6249699594

base is current main, sample is this PR

