### PR TITLE
Make bool(expr) raise

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2236,6 +2236,7 @@ def optimize_blockwise_fusion(expr):
                             dependencies[next._name].add(operand._name)
                         dependents[operand._name].add(next._name)
                         expr_mapping[operand._name] = operand
+                        expr_mapping[next._name] = next
 
         # Traverse each "root" until we find a fusable sub-group.
         # Here we use root to refer to a Blockwise Expr node that
@@ -2243,7 +2244,8 @@ def optimize_blockwise_fusion(expr):
         roots = [
             expr_mapping[k]
             for k, v in dependents.items()
-            if v == set() or all(not isinstance(_expr, Blockwise) for _expr in v)
+            if v == set()
+            or all(not isinstance(expr_mapping[_expr], Blockwise) for _expr in v)
         ]
         while roots:
             root = roots.pop()
@@ -2292,7 +2294,8 @@ def optimize_blockwise_fusion(expr):
                         if operand._name not in local_names
                     ]
                 to_replace = {group[0]._name: Fused(group, *group_deps)}
-                return expr.substitute(to_replace), not roots
+                _ret = expr.substitute(to_replace)
+                return _ret, not roots
 
         # Return original expr if no fusable sub-groups were found
         return expr, True

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -772,7 +772,7 @@ class Expr:
 
         Examples
         --------
-        >>> (df + 10).substitute({10: 20})
+        >>> (df + 10).substitute(10, 20)
         df + 20
         """
 

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -301,7 +301,8 @@ class Merge(Expr):
                 columns.remove(_HASH_COLUMN_NAME)
             if sorted(common.columns) != sorted(columns):
                 common = common[columns]
-            common = common._simplify_down() or common
+            c = common._simplify_down()
+            common = c if c is not None else common
             return common
 
 

--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -779,7 +779,7 @@ class SetIndex(BaseSetIndexSortValues):
             if any(isinstance(x, Index) for x in p.walk()):
                 # Punt on cases where the new index is part of the filter
                 return
-            predicate = parent.substitute({self: self.frame}).predicate
+            predicate = parent.substitute(self, self.frame).predicate
             return type(self)(self.frame[predicate], *self.operands[1:])
 
 

--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -857,7 +857,9 @@ class SortValues(BaseSetIndexSortValues):
                 return NSmallest(self.frame, n=parent.n, _columns=self.by)
         if isinstance(parent, Filter):
             return SortValues(
-                Filter(self.frame, parent.predicate.substitute({self: self.frame})),
+                Filter(
+                    self.frame, parent.predicate.substitute({self._name: self.frame})
+                ),
                 *self.operands[1:],
             )
         if isinstance(parent, Projection):

--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -857,7 +857,7 @@ class SortValues(BaseSetIndexSortValues):
                 return NSmallest(self.frame, n=parent.n, _columns=self.by)
         if isinstance(parent, Filter):
             return SortValues(
-                Filter(self.frame, parent.predicate.substitute([(self, self.frame)])),
+                Filter(self.frame, parent.predicate.substitute(self, self.frame)),
                 *self.operands[1:],
             )
         if isinstance(parent, Projection):

--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -857,9 +857,7 @@ class SortValues(BaseSetIndexSortValues):
                 return NSmallest(self.frame, n=parent.n, _columns=self.by)
         if isinstance(parent, Filter):
             return SortValues(
-                Filter(
-                    self.frame, parent.predicate.substitute({self._name: self.frame})
-                ),
+                Filter(self.frame, parent.predicate.substitute([(self, self.frame)])),
                 *self.operands[1:],
             )
         if isinstance(parent, Projection):

--- a/dask_expr/_util.py
+++ b/dask_expr/_util.py
@@ -26,7 +26,14 @@ def _convert_to_list(column) -> list | None:
 
 def is_scalar(x):
     # np.isscalar does not work for some pandas scalars, for example pd.NA
-    return not (isinstance(x, Sequence) or hasattr(x, "dtype")) or isinstance(x, str)
+    if isinstance(x, Sequence) and not isinstance(x, str) or hasattr(x, "dtype"):
+        return False
+    if isinstance(x, (str, int)):
+        return True
+
+    from dask_expr._expr import Expr
+
+    return not isinstance(x, Expr)
 
 
 @normalize_token.register(LambdaType)

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -587,23 +587,23 @@ def test_substitute():
     df = from_pandas(pdf, npartitions=3)
     df = df.expr
 
-    result = (df + 1).substitute([(1, 2)])
+    result = (df + 1).substitute(1, 2)
     expected = df + 2
     assert result._name == expected._name
 
-    result = df["a"].substitute([(df["a"], df["b"])])
+    result = df["a"].substitute(df["a"], df["b"])
     expected = df["b"]
     assert result._name == expected._name
 
-    result = (df["a"] - df["b"]).substitute([(df["b"], df["c"])])
+    result = (df["a"] - df["b"]).substitute(df["b"], df["c"])
     expected = df["a"] - df["c"]
     assert result._name == expected._name
 
-    result = df["a"].substitute([(3, 4)])
+    result = df["a"].substitute(3, 4)
     expected = from_pandas(pdf, npartitions=4).a
     assert result._name == expected._name
 
-    result = (df["a"].sum() + 5).substitute([(df["a"], df["b"]), (5, 6)])
+    result = (df["a"].sum() + 5).substitute(df["a"], df["b"]).substitute(5, 6)
     expected = df["b"].sum() + 6
     assert result._name == expected._name
 

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -1220,3 +1220,8 @@ def test_drop_duplicates_groupby(pdf):
     query = df.groupby("y").z.count()
     expected = pdf.drop_duplicates(subset="x").groupby("y").z.count()
     assert_eq(query, expected)
+
+
+def test_expression_bool_raises(df):
+    with pytest.raises(ValueError, match="The truth value"):
+        bool(df.expr)

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -10,7 +10,7 @@ from dask.dataframe._compat import PANDAS_GE_210
 from dask.dataframe.utils import UNKNOWN_CATEGORIES, assert_eq
 from dask.utils import M
 
-from dask_expr import expr, from_pandas, optimize
+from dask_expr import expr, from_pandas, is_scalar, optimize
 from dask_expr._expr import are_co_aligned
 from dask_expr._reductions import Len
 from dask_expr.datasets import timeseries
@@ -1225,3 +1225,9 @@ def test_drop_duplicates_groupby(pdf):
 def test_expression_bool_raises(df):
     with pytest.raises(ValueError, match="The truth value"):
         bool(df.expr)
+
+
+def test_expr_is_scalar(df):
+    assert not is_scalar(df.expr)
+    with pytest.raises(ValueError, match="The truth value"):
+        df.expr.x in df.expr.columns  # noqa: B015

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -587,23 +587,23 @@ def test_substitute():
     df = from_pandas(pdf, npartitions=3)
     df = df.expr
 
-    result = (df + 1).substitute({1: 2})
+    result = (df + 1).substitute([(1, 2)])
     expected = df + 2
     assert result._name == expected._name
 
-    result = df["a"].substitute({df["a"]._name: df["b"]})
+    result = df["a"].substitute([(df["a"], df["b"])])
     expected = df["b"]
     assert result._name == expected._name
 
-    result = (df["a"] - df["b"]).substitute({df["b"]._name: df["c"]})
+    result = (df["a"] - df["b"]).substitute([(df["b"], df["c"])])
     expected = df["a"] - df["c"]
     assert result._name == expected._name
 
-    result = df["a"].substitute({3: 4})
+    result = df["a"].substitute([(3, 4)])
     expected = from_pandas(pdf, npartitions=4).a
     assert result._name == expected._name
 
-    result = (df["a"].sum() + 5).substitute({df["a"]._name: df["b"], 5: 6})
+    result = (df["a"].sum() + 5).substitute([(df["a"], df["b"]), (5, 6)])
     expected = df["b"].sum() + 6
     assert result._name == expected._name
 


### PR DESCRIPTION
fusing is based on names now, which means we have to keep track of the associated expression, everything else is an easy change.


I think this makes more sense long-term compared to bool(expr) always returning True


alternative to #304