### PR TITLE
[Proposal] Provide limited support for pandas<2.0

### DIFF
--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import toolz
 from dask.dataframe import hyperloglog, methods
+from dask.dataframe._compat import PANDAS_GE_200
 from dask.dataframe.core import (
     _concat,
     idxmaxmin_agg,
@@ -293,7 +294,9 @@ class DropDuplicates(Unique):
 
     @property
     def chunk_kwargs(self):
-        return {"ignore_index": self.ignore_index, **self._subset_kwargs()}
+        if PANDAS_GE_200:
+            return {"ignore_index": self.ignore_index, **self._subset_kwargs()}
+        return self._subset_kwargs()
 
     def _simplify_up(self, parent):
         if self.subset is not None and isinstance(parent, Projection):

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -6,7 +6,7 @@ import pickle
 import dask
 import numpy as np
 import pytest
-from dask.dataframe._compat import PANDAS_GE_210
+from dask.dataframe._compat import PANDAS_GE_200, PANDAS_GE_210
 from dask.dataframe.utils import UNKNOWN_CATEGORIES, assert_eq
 from dask.utils import M
 
@@ -784,6 +784,8 @@ def test_map_partitions_merge(opt):
     # Check result with/without fusion
     expect = pdf1.merge(pdf2, on="x")
     df3 = (df3.optimize() if opt else df3)[list(expect.columns)]
+    if not PANDAS_GE_200:
+        df3 = df3.reset_index(drop=True)
     assert_eq(df3, expect, check_index=False)
 
 

--- a/dask_expr/tests/test_datasets.py
+++ b/dask_expr/tests/test_datasets.py
@@ -2,8 +2,8 @@ import pickle
 import sys
 
 import pytest
-from dask.dataframe.utils import assert_eq
 from dask.dataframe._compat import PANDAS_GE_200
+from dask.dataframe.utils import assert_eq
 
 from dask_expr import new_collection
 from dask_expr._expr import Lengths

--- a/dask_expr/tests/test_datasets.py
+++ b/dask_expr/tests/test_datasets.py
@@ -3,6 +3,7 @@ import sys
 
 import pytest
 from dask.dataframe.utils import assert_eq
+from dask.dataframe._compat import PANDAS_GE_200
 
 from dask_expr import new_collection
 from dask_expr._expr import Lengths
@@ -111,5 +112,6 @@ def test_timeseries_gaph_size(seed):
     ddf = dd_timeseries(seed=seed)
     graph_size = sys.getsizeof(pickle.dumps(df.dask))
     graph_size_dd = sys.getsizeof(pickle.dumps(dict(ddf.dask)))
-    # Make sure we are within 10% of dask.dataframe graph size
-    assert graph_size < 1.10 * graph_size_dd
+    # Make sure we are close to the dask.dataframe graph size
+    threshold = 1.10 if PANDAS_GE_200 else 1.50
+    assert graph_size < threshold * graph_size_dd

--- a/dask_expr/tests/test_string_accessor.py
+++ b/dask_expr/tests/test_string_accessor.py
@@ -1,5 +1,6 @@
 import pytest
 from dask.dataframe import assert_eq
+from dask.dataframe._compat import PANDAS_GE_200
 
 from dask_expr._collection import from_pandas
 from dask_expr.tests._util import _backend_library
@@ -26,7 +27,13 @@ def dser(ser):
         ("contains", {"pat": "a"}),
         ("count", {"pat": "a"}),
         ("endswith", {"pat": "a"}),
-        ("extract", {"pat": r"[ab](\d)"}),
+        pytest.param(
+            "extract", {"pat": r"[ab](\d)"},
+            marks=pytest.mark.skipif(
+                not PANDAS_GE_200,
+                reason="Index metadata wrong for pandas<2.0",
+            ),
+        ),
         ("extractall", {"pat": r"[ab](\d)"}),
         ("find", {"sub": "a"}),
         ("findall", {"pat": "a"}),

--- a/dask_expr/tests/test_string_accessor.py
+++ b/dask_expr/tests/test_string_accessor.py
@@ -28,7 +28,8 @@ def dser(ser):
         ("count", {"pat": "a"}),
         ("endswith", {"pat": "a"}),
         pytest.param(
-            "extract", {"pat": r"[ab](\d)"},
+            "extract",
+            {"pat": r"[ab](\d)"},
             marks=pytest.mark.skipif(
                 not PANDAS_GE_200,
                 reason="Index metadata wrong for pandas<2.0",


### PR DESCRIPTION
In the past, I've mentioned that cudf had fallen a bit behind in terms of pandas-2.0 support. It is starting to look like cudf will **not** be supporting pandas>1.5.3 until December 2023 at the very earliest.

Since it has become challenging for me to test dask-expr + cudf with pandas-2.0 support, I'd like to propose that dask-expr provide limited support for pandas<2.0 until cudf catches up.  This is **not** a suggestion that we directly prioritize, test or advertise pandas<2.0 support in any way. Rather, I am hoping that we can acknowledge that anyone using a `cudf` backend will also need to have `pandas<=1.5.3` in their environment, and so (for now) we add a few `PANDAS_GE_200` checks to the code base.

Please keep in mind that I really do want to avoid unnecessary compatibility checks in dask-expr.  However, I just don't think that avoiding these checks is worth the current development pain I am facing.