### PR TITLE
Avoid filter push-up when there is nothing to gain

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1130,8 +1130,17 @@ class Blockwise(Expr):
                 # (There is no guarentee that the same method will exist for
                 # both a Series and DataFrame)
                 return None
+
+            others = self._find_similar_operations(root, ignore=self._parameters)
+            if isinstance(self.frame, Filter) and all(
+                isinstance(op.frame, Filter) for op in others
+            ):
+                # Avoid pushing filters up if all similar ops
+                # are acting on a Filter-based expression anyway
+                return None
+
             push_up_op = False
-            for op in self._find_similar_operations(root, ignore=self._parameters):
+            for op in others:
                 if (
                     isinstance(op.frame, (Projection, Filter))
                     and (

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -1231,3 +1231,26 @@ def test_expr_is_scalar(df):
     assert not is_scalar(df.expr)
     with pytest.raises(ValueError, match="The truth value"):
         df.expr.x in df.expr.columns  # noqa: B015
+
+
+def test_replace_filtered_combine_similar():
+    from dask_expr._expr import Filter, Replace
+
+    pdf = lib.DataFrame({"a": [1, 2, 3, 4, 5, 6], "b": 1, "c": 2})
+
+    df = from_pandas(pdf.copy(), npartitions=2)
+    df = df[df.a > 3]
+    df = df.replace(5, 4)
+    df["new"] = df.a + df.b
+
+    pdf = pdf[pdf.a > 3]
+    pdf = pdf.replace(5, 4)
+    pdf["new"] = pdf.a + pdf.b
+
+    df = df.optimize(fuse=False)
+    assert_eq(df, pdf)  # Check result
+
+    # Check that Replace expressions always operate on
+    # Filter expressions (and not the other way around)
+    similar = list(df.find_operations(Replace))
+    assert all(isinstance(op.frame, Filter) for op in similar)


### PR DESCRIPTION
Addresses #313 by avoiding `Filter` push-up in `combine_similar` when all "similar" operations are also acting on a `Filter` expression (even if the `predicate` used in some of these similar operations are different). It seems unlikely that we will ever gain anything by pushing up filters in cases like this.

- closes #313