### PR TITLE
Revise `Expr.substitute` to distinguish literal-value substitution

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -827,6 +827,21 @@ class Expr:
                     update = True
                 new_exprs.append(val)
             elif (
+                isinstance(self, Fused)
+                and isinstance(operand, list)
+                and all(isinstance(op, Expr) for op in operand)
+            ):
+                # Special handling for `Fused`.
+                # We make no promise to dive through a
+                # list operand in general, but NEED to
+                # do so for the `Fused.exprs` operand.
+                val = []
+                for op in operand:
+                    val.append(op.substitute(old, new))
+                    if val[-1]._name != op._name:
+                        update = True
+                new_exprs.append(val)
+            elif (
                 substitute_literal
                 and not isinstance(operand, bool)
                 and isinstance(operand, type(old))

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -789,14 +789,18 @@ class Expr:
         return [(self._name, i) for i in range(self.npartitions)]
 
     def substitute(self, old, new) -> Expr:
-        """Substitute specific `Expr` instances within `self`
+        """Substitute a specific term within the expression
+
+        Note that replacing non-`Expr` terms may produce
+        unexpected results, and is not recommended.
+        Substituting boolean values is not allowed.
 
         Parameters
         ----------
-        substitutions:
-            mapping old terms to new terms. Note that using
-            non-`Expr` keys may produce unexpected results,
-            and substituting boolean values is not allowed.
+        old:
+            Old term to find and replace.
+        new:
+            New term to replace instances of `old` with.
 
         Examples
         --------


### PR DESCRIPTION
The current implementation of `Expr.substitute` does not work with `cudf`-backed collections, because `cudf` objects are "hashable."  This PR revises the logic a bit to distinguish the logic used for `Expr` and literal terms a bit more clearly.