### PR TITLE
Use ``_required_attribute`` in ``idxmin/max``

### DIFF
--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -546,16 +546,16 @@ class IdxMin(Reduction):
     reduction_chunk = idxmaxmin_chunk
     reduction_combine = idxmaxmin_combine
     reduction_aggregate = idxmaxmin_agg
-    _fn = "idxmin"
+    _required_attribute = "idxmin"
 
     @property
     def chunk_kwargs(self):
         # TODO: Add numeric_only after Dask release on May 26th
-        return dict(skipna=self.skipna, fn=self._fn)
+        return dict(skipna=self.skipna, fn=self._required_attribute)
 
     @property
     def combine_kwargs(self):
-        return dict(skipna=self.skipna, fn=self._fn)
+        return dict(skipna=self.skipna, fn=self._required_attribute)
 
     @property
     def aggregate_kwargs(self):
@@ -563,7 +563,7 @@ class IdxMin(Reduction):
 
 
 class IdxMax(IdxMin):
-    _fn = "idxmax"
+    _required_attribute = "idxmax"
 
 
 class Len(Reduction):


### PR DESCRIPTION
Since cudf does not support `idxmin/max`, the `_required_attribute` property needs to be set to avoid recursive `getattr` "hang".