### PR TITLE
Avoid top-level ``distributed`` import in ``_merge.py``

### DIFF
--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -3,9 +3,6 @@ import functools
 from dask.core import flatten
 from dask.dataframe.dispatch import make_meta, meta_nonempty
 from dask.utils import M, apply, get_default_shuffle_method
-from distributed.shuffle._core import ShuffleId, barrier_key
-from distributed.shuffle._merge import merge_transfer, merge_unpack
-from distributed.shuffle._shuffle import shuffle_barrier
 
 from dask_expr._expr import (
     Blockwise,
@@ -348,6 +345,10 @@ class HashJoinP2P(Merge, PartitionsFiltered):
         )
 
     def _layer(self) -> dict:
+        from distributed.shuffle._core import ShuffleId, barrier_key
+        from distributed.shuffle._merge import merge_transfer, merge_unpack
+        from distributed.shuffle._shuffle import shuffle_barrier
+
         dsk = {}
         name_left = "hash-join-transfer-" + self.left._name
         name_right = "hash-join-transfer-" + self.right._name

--- a/dask_expr/tests/test_distributed.py
+++ b/dask_expr/tests/test_distributed.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import pytest
-from distributed import Client, LocalCluster
 
 from dask_expr import from_pandas
 from dask_expr.tests._util import _backend_library
 
 distributed = pytest.importorskip("distributed")
 
+from distributed import Client, LocalCluster
 from distributed.utils_test import client as c  # noqa F401
 from distributed.utils_test import gen_cluster
 


### PR DESCRIPTION
We are currently importing `distributed` at the top of `_merge.py`. However, `distributed` is not a required dependency for `dask-expr`. Therefore, this PR moves the offending imports to the `_layer` method that requires it.