### PR TITLE
Fix ``Concat`` after ``Merge``

### DIFF
--- a/dask_expr/_concat.py
+++ b/dask_expr/_concat.py
@@ -99,7 +99,7 @@ class Concat(Expr):
             # dtypes of all dfs need to be coherent
             # refer to https://github.com/dask/dask/issues/4685
             # and https://github.com/dask/dask/issues/5968.
-            if is_dataframe_like(df):
+            if is_dataframe_like(df._meta):
                 shared_columns = list(set(df.columns).intersection(self._meta.columns))
                 needs_astype = {
                     col: self._meta[col].dtype

--- a/dask_expr/_concat.py
+++ b/dask_expr/_concat.py
@@ -99,7 +99,7 @@ class Concat(Expr):
             # dtypes of all dfs need to be coherent
             # refer to https://github.com/dask/dask/issues/4685
             # and https://github.com/dask/dask/issues/5968.
-            if is_dataframe_like(df.frame):
+            if is_dataframe_like(df):
                 shared_columns = list(set(df.columns).intersection(self._meta.columns))
                 needs_astype = {
                     col: self._meta[col].dtype


### PR DESCRIPTION
There is a subtle bug in `Concat` that shows up when one of the dependencies does not have a "frame" operand.