### PR TITLE
Add ``_BackendData`` utility class to improve ``FromParquet`` caching

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -48,7 +48,7 @@ from dask_expr._reductions import (
 from dask_expr._repartition import Repartition
 from dask_expr._shuffle import SetIndex, SetIndexBlockwise, SortValues
 from dask_expr._str_accessor import StringAccessor
-from dask_expr._util import _convert_to_list, is_scalar
+from dask_expr._util import _BackendData, _convert_to_list, is_scalar
 
 #
 # Utilities to wrap Expr API
@@ -1113,7 +1113,7 @@ def optimize(collection, fuse=True):
 
 
 def from_pandas(data, npartitions=1, sort=True):
-    from dask_expr.io.io import FromPandas, _BackendData
+    from dask_expr.io.io import FromPandas
 
     return new_collection(
         FromPandas(

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -1113,9 +1113,15 @@ def optimize(collection, fuse=True):
 
 
 def from_pandas(data, npartitions=1, sort=True):
-    from dask_expr.io.io import FromPandas
+    from dask_expr.io.io import FromPandas, _BackendData
 
-    return new_collection(FromPandas(data.copy(), npartitions=npartitions, sort=sort))
+    return new_collection(
+        FromPandas(
+            _BackendData(data.copy()),
+            npartitions=npartitions,
+            sort=sort,
+        )
+    )
 
 
 def from_graph(*args, **kwargs):

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -29,7 +29,7 @@ from dask.typing import no_default
 from dask.utils import M, apply, funcname, import_required, is_arraylike
 from tlz import merge_sorted, unique
 
-from dask_expr._util import _tokenize_deterministic, _tokenize_partial
+from dask_expr._util import _BackendData, _tokenize_deterministic, _tokenize_partial
 
 replacement_rules = []
 
@@ -100,6 +100,9 @@ class Expr:
                 except (IndexError, KeyError):
                     param = self._parameters[i] if i < len(self._parameters) else ""
                     default = "--no-default--"
+
+                if isinstance(op, _BackendData):
+                    op = op._data
 
                 if isinstance(op, pd.core.base.PandasObject):
                     op = "<pandas>"

--- a/dask_expr/_util.py
+++ b/dask_expr/_util.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import functools
 from collections import OrderedDict, UserDict
 from collections.abc import Hashable, Sequence
 from types import LambdaType
-from typing import TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from dask import config
 from dask.base import normalize_token, tokenize
@@ -77,3 +78,39 @@ class LRU(UserDict[K, V]):
         if len(self) >= self.maxsize:
             cast(OrderedDict, self.data).popitem(last=False)
         super().__setitem__(key, value)
+
+
+class _BackendData:
+    """Helper class to wrap backend data
+
+    The primary purpose of this class is to provide
+    caching outside the ``FromPandas`` class.
+    """
+
+    def __init__(self, data):
+        self._data = data
+        self._division_info = {}
+
+    @functools.cached_property
+    def _token(self):
+        from dask_expr._util import _tokenize_deterministic
+
+        return _tokenize_deterministic(self._data)
+
+    def __len__(self):
+        return len(self._data)
+
+    def __getattr__(self, key: str) -> Any:
+        try:
+            return object.__getattribute__(self, key)
+        except AttributeError:
+            # Return the underlying backend attribute
+            return getattr(self._data, key)
+
+    def __reduce__(self):
+        return type(self), (self._data,)
+
+
+@normalize_token.register(_BackendData)
+def normalize_data_wrapper(data):
+    return data._token

--- a/dask_expr/_util.py
+++ b/dask_expr/_util.py
@@ -89,7 +89,7 @@ class _BackendData:
 
     def __init__(self, data):
         self._data = data
-        self._division_info = {}
+        self._division_info = LRU(10)
 
     @functools.cached_property
     def _token(self):


### PR DESCRIPTION
While exploring the naively-implemented tpch queries in pola-rs/tpch (using scale-factor 1), I noticed that optimization performance is terrible for complicated queries containing `FromPandas` expressions. This is because we end up calling `tokenize` and `_divisions_and_locations` on the backend data repetitively.

This PR adds a `_BackendData` helper class to effectively wrap the backend data so we we can cache the results of  `tokenize` and `_divisions_and_locations` **outside** the `FromPandas` class.