### PR TITLE
Fix ``sort_values`` behavior for "tasks"-based shuffle and add missing kwargs

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -920,6 +920,8 @@ class DataFrame(FrameBase):
         sort_function: Callable[[pd.DataFrame], pd.DataFrame] | None = None,
         sort_function_kwargs: Mapping[str, Any] | None = None,
         upsample: float = 1.0,
+        ignore_index: bool | None = False,
+        shuffle: str | None = None,
     ):
         """See DataFrame.sort_values for docstring"""
         if na_position not in ("first", "last"):
@@ -957,6 +959,8 @@ class DataFrame(FrameBase):
                 sort_function,
                 sort_function_kwargs,
                 upsample,
+                ignore_index,
+                shuffle,
             )
         )
 

--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -219,20 +219,21 @@ class SimpleShuffle(PartitionsFiltered, ShuffleBackend):
         if npartitions_out < frame.npartitions:
             frame = Repartition(frame, n=npartitions_out)
 
-        if cls.lazy_hash_support:
-            # Don't need to assign "_partitions" column
-            # if we are shuffling on a list of columns
-            nset = set(partitioning_index)
-            if nset & set(frame.columns) == nset:
-                return cls(
-                    frame,
-                    partitioning_index,
-                    npartitions_out,
-                    ignore_index,
-                    options,
-                )
-
         if partitioning_index != ["_partitions"]:
+
+            if cls.lazy_hash_support:
+                # Don't need to assign "_partitions" column
+                # if we are shuffling on a list of columns
+                nset = set(partitioning_index)
+                if nset & set(frame.columns) == nset:
+                    return cls(
+                        frame,
+                        partitioning_index,
+                        npartitions_out,
+                        ignore_index,
+                        options,
+                    )
+
             # Assign new "_partitions" column
             index_added = AssignPartitioningIndex(
                 frame,
@@ -794,6 +795,8 @@ class SortValues(BaseSetIndexSortValues):
         "sort_function",
         "sort_function_kwargs",
         "upsample",
+        "ignore_index",
+        "shuffle",  # Shuffle backend
     ]
     _defaults = {
         "partition_size": 128e6,
@@ -803,6 +806,8 @@ class SortValues(BaseSetIndexSortValues):
         "sort_function": None,
         "sort_function_kwargs": None,
         "upsample": 1.0,
+        "ignore_index": False,
+        "shuffle": None,
     }
 
     def _divisions(self):
@@ -829,6 +834,7 @@ class SortValues(BaseSetIndexSortValues):
             "by": self.by,
             "ascending": self.ascending,
             "na_position": self.na_position,
+            "ignore_index": self.ignore_index,
         }
         if self.operand("sort_function_kwargs") is not None:
             sort_kwargs.update(self.operand("sort_function_kwargs"))
@@ -856,7 +862,8 @@ class SortValues(BaseSetIndexSortValues):
             assigned,
             "_partitions",
             npartitions_out=len(divisions) - 1,
-            ignore_index=True,
+            ignore_index=self.ignore_index,
+            backend=self.shuffle,
         )
         return SortValuesBlockwise(
             shuffled, self.sort_function, self.sort_function_kwargs

--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -220,7 +220,6 @@ class SimpleShuffle(PartitionsFiltered, ShuffleBackend):
             frame = Repartition(frame, n=npartitions_out)
 
         if partitioning_index != ["_partitions"]:
-
             if cls.lazy_hash_support:
                 # Don't need to assign "_partitions" column
                 # if we are shuffling on a list of columns

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -223,20 +223,21 @@ def test_set_index_without_sort(df, pdf):
         df.set_index("y", sorted=True, npartitions=20)
 
 
-def test_sort_values(df, pdf):
-    assert_eq(df.sort_values("x"), pdf.sort_values("x"))
-    assert_eq(df.sort_values("x", npartitions=2), pdf.sort_values("x"))
+@pytest.mark.parametrize("method", [None, "tasks"])
+def test_sort_values(df, pdf, method):
+    assert_eq(df.sort_values("x", shuffle=method), pdf.sort_values("x"))
+    assert_eq(df.sort_values("x", shuffle=method, npartitions=2), pdf.sort_values("x"))
     pdf.iloc[5, 0] = -10
     df = from_pandas(pdf, npartitions=10)
-    assert_eq(df.sort_values("x", upsample=2.0), pdf.sort_values("x"))
+    assert_eq(df.sort_values("x", shuffle=method, upsample=2.0), pdf.sort_values("x"))
 
     with pytest.raises(NotImplementedError, match="a single boolean for ascending"):
-        df.sort_values(by=["x", "y"], ascending=[True, True])
+        df.sort_values(by=["x", "y"], shuffle=method, ascending=[True, True])
     with pytest.raises(NotImplementedError, match="sorting by named columns"):
-        df.sort_values(by=1)
+        df.sort_values(by=1, shuffle=method)
 
     with pytest.raises(ValueError, match="must be either 'first' or 'last'"):
-        df.sort_values(by="x", na_position="bla")
+        df.sort_values(by="x", shuffle=method, na_position="bla")
 
 
 def test_sort_values_optimize(df, pdf):

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -223,21 +223,21 @@ def test_set_index_without_sort(df, pdf):
         df.set_index("y", sorted=True, npartitions=20)
 
 
-@pytest.mark.parametrize("method", [None, "tasks"])
-def test_sort_values(df, pdf, method):
-    assert_eq(df.sort_values("x", shuffle=method), pdf.sort_values("x"))
-    assert_eq(df.sort_values("x", shuffle=method, npartitions=2), pdf.sort_values("x"))
+@pytest.mark.parametrize("shuffle", [None, "tasks"])
+def test_sort_values(df, pdf, shuffle):
+    assert_eq(df.sort_values("x", shuffle=shuffle), pdf.sort_values("x"))
+    assert_eq(df.sort_values("x", shuffle=shuffle, npartitions=2), pdf.sort_values("x"))
     pdf.iloc[5, 0] = -10
     df = from_pandas(pdf, npartitions=10)
-    assert_eq(df.sort_values("x", shuffle=method, upsample=2.0), pdf.sort_values("x"))
+    assert_eq(df.sort_values("x", shuffle=shuffle, upsample=2.0), pdf.sort_values("x"))
 
     with pytest.raises(NotImplementedError, match="a single boolean for ascending"):
-        df.sort_values(by=["x", "y"], shuffle=method, ascending=[True, True])
+        df.sort_values(by=["x", "y"], shuffle=shuffle, ascending=[True, True])
     with pytest.raises(NotImplementedError, match="sorting by named columns"):
-        df.sort_values(by=1, shuffle=method)
+        df.sort_values(by=1, shuffle=shuffle)
 
     with pytest.raises(ValueError, match="must be either 'first' or 'last'"):
-        df.sort_values(by="x", shuffle=method, na_position="bla")
+        df.sort_values(by="x", shuffle=shuffle, na_position="bla")
 
 
 def test_sort_values_optimize(df, pdf):

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -240,6 +240,17 @@ def test_sort_values(df, pdf, shuffle):
         df.sort_values(by="x", shuffle=shuffle, na_position="bla")
 
 
+@pytest.mark.parametrize("shuffle", [None, "tasks"])
+def test_sort_values_temporary_column_dropped(shuffle):
+    pdf = lib.DataFrame(
+        {"x": range(10), "y": [1, 2, 3, 4, 5] * 2, "z": ["cat", "dog"] * 5}
+    )
+    df = from_pandas(pdf, npartitions=2)
+    _sorted = df.sort_values(["z"], shuffle=shuffle)
+    result = _sorted.compute()
+    assert "_partitions" not in result.columns
+
+
 def test_sort_values_optimize(df, pdf):
     q = df.sort_values("x")["y"].optimize(fuse=False)
     expected = df[["x", "y"]].sort_values("x")["y"].optimize(fuse=False)


### PR DESCRIPTION
While exploring ways to make `sort_values` work with a cudf backend, I discovered that `main` will currently return wrong results when the "dataframe.shuffle.method" configuration is set to "tasks". This PR fixes the underlying bug, and adds `shuffle` and `ignore_index` parameters (to `SortValues`) to make this behavior easier to test/control.