### PR TITLE
Avoid ``operation`` methods in ``Blockwise`` subclasses

### DIFF
--- a/dask_expr/_accessor.py
+++ b/dask_expr/_accessor.py
@@ -72,7 +72,8 @@ class PropertyMap(Elemwise):
         "attr",
     ]
 
-    def operation(self, obj, accessor, attr):
+    @staticmethod
+    def operation(obj, accessor, attr):
         out = getattr(getattr(obj, accessor, obj), attr)
         return maybe_wrap_pandas(obj, out)
 
@@ -80,6 +81,7 @@ class PropertyMap(Elemwise):
 class FunctionMap(Elemwise):
     _parameters = ["frame", "accessor", "attr", "args", "kwargs"]
 
-    def operation(self, obj, accessor, attr, args, kwargs):
+    @staticmethod
+    def operation(obj, accessor, attr, args, kwargs):
         out = getattr(getattr(obj, accessor, obj), attr)(*args, **kwargs)
         return maybe_wrap_pandas(obj, out)

--- a/dask_expr/_concat.py
+++ b/dask_expr/_concat.py
@@ -203,5 +203,6 @@ class ConcatUnindexed(Blockwise):
             **self.operand("_kwargs"),
         )
 
-    def operation(self, *args, ignore_order, _kwargs):
+    @staticmethod
+    def operation(*args, ignore_order, _kwargs):
         return concat_and_check(args, ignore_order=ignore_order)

--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -40,9 +40,6 @@ class GroupByChunk(Chunk):
     _parameters = Chunk._parameters + ["by"]
     _defaults = Chunk._defaults | {"by": None}
 
-    def operation(self, df, by, *args, **kwargs):
-        return self.chunk(df, by, *args, **kwargs)
-
     @functools.cached_property
     def _args(self) -> list:
         return [self.frame, self.by]

--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -35,8 +35,13 @@ class Chunk(Blockwise):
 
     _parameters = ["frame", "kind", "chunk", "chunk_kwargs"]
 
-    def operation(self, df, *args, **kwargs):
-        return self.chunk(df, *args, **kwargs)
+    @staticmethod
+    def chunk_operation(op, *args, **kwargs):
+        return op(*args, **kwargs)
+
+    @property
+    def operation(self):
+        return functools.partial(self.chunk_operation, self.chunk)
 
     @functools.cached_property
     def _args(self) -> list:

--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -607,8 +607,8 @@ class AssignPartitioningIndex(Blockwise):
 
     _parameters = ["frame", "partitioning_index", "index_name", "npartitions_out"]
 
-    @classmethod
-    def operation(cls, df, index, name: str, npartitions: int):
+    @staticmethod
+    def operation(df, index, name: str, npartitions: int):
         """Construct a hash-based partitioning index"""
         index = _select_columns_or_index(df, index)
         if isinstance(index, (str, list, tuple)):
@@ -958,7 +958,8 @@ class _SetIndexPost(Blockwise):
     _parameters = ["frame", "index_name", "drop", "set_name"]
     _is_length_preserving = True
 
-    def operation(self, df, index_name, drop, set_name):
+    @staticmethod
+    def operation(df, index_name, drop, set_name):
         return df.set_index(set_name, drop=drop).rename_axis(index=index_name)
 
 
@@ -975,7 +976,8 @@ class SortValuesBlockwise(Blockwise):
     _keyword_only = ["sort_function", "sort_kwargs"]
     _is_length_preserving = True
 
-    def operation(self, *args, **kwargs):
+    @staticmethod
+    def operation(*args, **kwargs):
         sort_func = kwargs.pop("sort_function")
         sort_kwargs = kwargs.pop("sort_kwargs")
         return sort_func(*args, **kwargs, **sort_kwargs)
@@ -990,7 +992,8 @@ class SetIndexBlockwise(Blockwise):
     _keyword_only = ["drop", "new_divisions"]
     _is_length_preserving = True
 
-    def operation(self, df, *args, new_divisions, **kwargs):
+    @staticmethod
+    def operation(df, *args, new_divisions, **kwargs):
         return df.set_index(*args, **kwargs)
 
     def _divisions(self):

--- a/dask_expr/_str_accessor.py
+++ b/dask_expr/_str_accessor.py
@@ -111,7 +111,8 @@ class StringAccessor(Accessor):
 class CatBlockwise(Blockwise):
     _parameters = ["frame", "others", "sep", "na_rep"]
 
-    def operation(self, ser, *args, **kwargs):
+    @staticmethod
+    def operation(ser, *args, **kwargs):
         return ser.str.cat(*args, **kwargs)
 
 


### PR DESCRIPTION
Motivated by https://github.com/dask-contrib/dask-expr/issues/323

Modifies all cases where `Blockwise.operation` is currently overridden as a method in a `Blockwise` subclass. Instead, we need to use a property and/or `staticmethod`.