### PR TITLE
Remove unnecessary indirection in ``Chunk.operation``

### DIFF
--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -35,13 +35,9 @@ class Chunk(Blockwise):
 
     _parameters = ["frame", "kind", "chunk", "chunk_kwargs"]
 
-    @staticmethod
-    def chunk_operation(op, *args, **kwargs):
-        return op(*args, **kwargs)
-
     @property
     def operation(self):
-        return functools.partial(self.chunk_operation, self.chunk)
+        return self.chunk
 
     @functools.cached_property
     def _args(self) -> list:


### PR DESCRIPTION
Minor follow-up to https://github.com/dask-contrib/dask-expr/pull/324