### PR TITLE
Make ``simplify`` and ``lower`` optional within ``Expr.optimize``

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -147,12 +147,16 @@ class FrameBase(DaskMethodsMixin):
             return new_collection(self.expr.__getitem__(other.expr))
         return new_collection(self.expr.__getitem__(other))
 
-    def persist(self, fuse=True, combine_similar=True, **kwargs):
-        out = self.optimize(combine_similar=combine_similar, fuse=fuse)
+    def persist(self, simplify=True, fuse=True, combine_similar=True, **kwargs):
+        out = self.optimize(
+            simplify=simplify, combine_similar=combine_similar, fuse=fuse
+        )
         return DaskMethodsMixin.persist(out, **kwargs)
 
-    def compute(self, fuse=True, combine_similar=True, **kwargs):
-        out = self.optimize(combine_similar=combine_similar, fuse=fuse)
+    def compute(self, simplify=True, fuse=True, combine_similar=True, **kwargs):
+        out = self.optimize(
+            simplify=simplify, combine_similar=combine_similar, fuse=fuse
+        )
         return DaskMethodsMixin.compute(out, **kwargs)
 
     def __dask_graph__(self):
@@ -171,9 +175,20 @@ class FrameBase(DaskMethodsMixin):
     def lower_once(self):
         return new_collection(self.expr.lower_once())
 
-    def optimize(self, combine_similar: bool = True, fuse: bool = True):
+    def optimize(
+        self,
+        lower: bool = True,
+        simplify: bool = True,
+        combine_similar: bool = True,
+        fuse: bool = True,
+    ):
         return new_collection(
-            self.expr.optimize(combine_similar=combine_similar, fuse=fuse)
+            self.expr.optimize(
+                lower=lower,
+                simplify=simplify,
+                combine_similar=combine_similar,
+                fuse=fuse,
+            )
         )
 
     @property

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -155,7 +155,7 @@ class FrameBase(DaskMethodsMixin):
 
     def compute(self, simplify=True, fuse=True, combine_similar=True, **kwargs):
         out = self.optimize(
-            simplify=simplify, combine_similar=combine_similar, fuse=fuse
+            lower=True, simplify=simplify, combine_similar=combine_similar, fuse=fuse
         )
         return DaskMethodsMixin.compute(out, **kwargs)
 

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -147,16 +147,12 @@ class FrameBase(DaskMethodsMixin):
             return new_collection(self.expr.__getitem__(other.expr))
         return new_collection(self.expr.__getitem__(other))
 
-    def persist(self, simplify=True, fuse=True, combine_similar=True, **kwargs):
-        out = self.optimize(
-            lower=True, simplify=simplify, combine_similar=combine_similar, fuse=fuse
-        )
+    def persist(self, fuse=True, combine_similar=True, **kwargs):
+        out = self.optimize(combine_similar=combine_similar, fuse=fuse)
         return DaskMethodsMixin.persist(out, **kwargs)
 
-    def compute(self, simplify=True, fuse=True, combine_similar=True, **kwargs):
-        out = self.optimize(
-            lower=True, simplify=simplify, combine_similar=combine_similar, fuse=fuse
-        )
+    def compute(self, fuse=True, combine_similar=True, **kwargs):
+        out = self.optimize(combine_similar=combine_similar, fuse=fuse)
         return DaskMethodsMixin.compute(out, **kwargs)
 
     def __dask_graph__(self):
@@ -178,14 +174,12 @@ class FrameBase(DaskMethodsMixin):
     def optimize(
         self,
         lower: bool = True,
-        simplify: bool = True,
         combine_similar: bool = True,
         fuse: bool = True,
     ):
         return new_collection(
             self.expr.optimize(
                 lower=lower,
-                simplify=simplify,
                 combine_similar=combine_similar,
                 fuse=fuse,
             )

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -149,7 +149,7 @@ class FrameBase(DaskMethodsMixin):
 
     def persist(self, simplify=True, fuse=True, combine_similar=True, **kwargs):
         out = self.optimize(
-            simplify=simplify, combine_similar=combine_similar, fuse=fuse
+            lower=True, simplify=simplify, combine_similar=combine_similar, fuse=fuse
         )
         return DaskMethodsMixin.persist(out, **kwargs)
 

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2163,7 +2163,6 @@ def normalize_expression(expr):
 def optimize(
     expr: Expr,
     lower: bool = True,
-    simplify: bool = True,
     combine_similar: bool = True,
     fuse: bool = True,
 ) -> Expr:
@@ -2182,8 +2181,6 @@ def optimize(
         Input expression to optimize
     lower:
         whether or not to lower abstract expressions
-    simplify:
-        whether or not to use class-based simplification
     combine_similar:
         whether or not to combine similar operations
         (like `ReadParquet`) to aggregate redundant work.
@@ -2200,17 +2197,14 @@ def optimize(
     """
 
     result = expr
-    if simplify or lower:
-        while True:
-            if simplify and lower:
-                out = result.simplify().lower_once()
-            elif simplify:
-                out = result.simplify()
-            else:
-                out = result.lower_once()
-            if out._name == result._name:
-                break
-            result = out
+    while True:
+        if lower:
+            out = result.simplify().lower_once()
+        else:
+            out = result.simplify()
+        if out._name == result._name:
+            break
+        result = out
 
     if combine_similar:
         result = result.combine_similar()

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2188,7 +2188,8 @@ def optimize(
         whether or not to combine similar operations
         (like `ReadParquet`) to aggregate redundant work.
     fuse:
-        whether or not to turn on blockwise fusion
+        whether or not to turn on blockwise fusion.
+        Fusion also requires ``lower == True``.
 
     See Also
     --------
@@ -2214,7 +2215,7 @@ def optimize(
     if combine_similar:
         result = result.combine_similar()
 
-    if fuse:
+    if fuse and lower:
         result = optimize_blockwise_fusion(result)
 
     return result

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -1260,8 +1260,7 @@ def test_replace_filtered_combine_similar():
 
 @pytest.mark.parametrize("fuse", [True, False])
 @pytest.mark.parametrize("combine_similar", [True, False])
-@pytest.mark.parametrize("simplify", [True, False])
-def test_optimize_lower_false(fuse, combine_similar, simplify):
+def test_optimize_lower_false(fuse, combine_similar):
     from dask_expr._shuffle import SortValues
 
     pdf = lib.DataFrame({"a": [1, 6, 2, 4, 5, 3], "b": 1, "c": 2})
@@ -1278,7 +1277,6 @@ def test_optimize_lower_false(fuse, combine_similar, simplify):
     result = df.optimize(
         lower=False,
         fuse=fuse,
-        simplify=simplify,
         combine_similar=combine_similar,
     )
 
@@ -1291,7 +1289,6 @@ def test_optimize_lower_false(fuse, combine_similar, simplify):
     assert_eq(
         result.compute(
             fuse=fuse,
-            simplify=simplify,
             combine_similar=combine_similar,
         ),
         expect,


### PR DESCRIPTION
I have found that it can sometimes be useful to avoid lowering within an `Expr.optimize` call, because it becomes a bit easier to inspect the behavior of `simplify` on an expression graph.