### PR TITLE
Add IO fusion if we can reduce number of partitions

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2249,7 +2249,10 @@ def optimize_io_fusion(expr):
         changed = False
         for operand in expr.operands:
             if isinstance(operand, Expr):
-                if isinstance(operand, BlockwiseIO) and operand._factor < 1:
+                if (
+                    isinstance(operand, BlockwiseIO)
+                    and operand._fusion_compression_factor < 1
+                ):
                     new = FusedIO(operand)
                 elif isinstance(operand, BlockwiseIO):
                     new = operand

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2249,9 +2249,8 @@ def optimize_io_fusion(expr):
         changed = False
         for operand in expr.operands:
             if isinstance(operand, Expr):
-                if isinstance(operand, BlockwiseIO) and operand._factor < 0.7:
+                if isinstance(operand, BlockwiseIO) and operand._factor < 1:
                     new = FusedIO(operand)
-                    new.npartitions
                 elif isinstance(operand, BlockwiseIO):
                     new = operand
                 else:

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -52,7 +52,7 @@ class BlockwiseIO(Blockwise, IO):
     _absorb_projections = False
 
     @functools.cached_property
-    def _factor(self):
+    def _fusion_compression_factor(self):
         return 1
 
     def _simplify_up(self, parent):
@@ -150,7 +150,7 @@ class FusedIO(BlockwiseIO):
 
     @functools.cached_property
     def _fusion_buckets(self):
-        step = math.ceil(1 / self.operand("expr")._factor)
+        step = math.ceil(1 / self.operand("expr")._fusion_compression_factor)
         partitions = self.operand("expr")._partitions
         npartitions = len(partitions)
         buckets = [partitions[i : i + step] for i in range(0, npartitions, step)]

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -645,6 +645,8 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
 
     @functools.cached_property
     def _factor(self):
+        if self.operand("columns") is None:
+            return 1
         nr_original_columns = len(self._dataset_info["schema"].names) - 1
         return len(_convert_to_list(self.operand("columns"))) / nr_original_columns
 

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -570,7 +570,11 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
             # Don't bother if the difference is too small
             return
         new_partitions = max(int(factor * self.npartitions), 1)
-        return RepartitionToFewer(self, new_partitions)
+        if new_partitions == self.npartitions:
+            return
+        return type(parent)(
+            RepartitionToFewer(self, new_partitions), *parent.operands[1:]
+        )
 
     @cached_property
     def _plan(self):

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -644,7 +644,7 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
                 )
 
     @functools.cached_property
-    def _factor(self):
+    def _fusion_compression_factor(self):
         if self.operand("columns") is None:
             return 1
         nr_original_columns = len(self._dataset_info["schema"].names) - 1

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -572,9 +572,7 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
         new_partitions = max(int(factor * self.npartitions), 1)
         if new_partitions == self.npartitions:
             return
-        return type(parent)(
-            RepartitionToFewer(self, new_partitions), *parent.operands[1:]
-        )
+        return parent.substitute(self, RepartitionToFewer(self, new_partitions))
 
     @cached_property
     def _plan(self):

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -164,6 +164,13 @@ def test_predicate_pushdown_compound(tmpdir):
     assert_eq(y, z)
 
 
+def test_io_fusion_blockwise(tmpdir):
+    pdf = lib.DataFrame({c: range(10) for c in "abcdefghijklmn"})
+    dd.from_pandas(pdf, 2).to_parquet(tmpdir)
+    df = read_parquet(tmpdir)["a"].fillna(10).optimize()
+    assert df.npartitions == 1
+
+
 @pytest.mark.parametrize("fmt", ["parquet", "csv", "pandas"])
 def test_io_culling(tmpdir, fmt):
     pdf = lib.DataFrame({c: range(10) for c in "abcde"})


### PR DESCRIPTION
We end up with a lot of small chunks if we can drop lots of columns from the parquet files. This is especially bad for P2P based merges, since small chunks slow us down there. Squashing the partitions together solves that problem so that we end up with the original chunksize