### PR TITLE
Avoid divisions calculation for one partition df in sort_values

### DIFF
--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -3,6 +3,7 @@ from dask.dataframe.utils import assert_eq
 
 from dask_expr import SetIndexBlockwise, from_pandas
 from dask_expr._expr import Blockwise
+from dask_expr._shuffle import divisions_lru
 from dask_expr.io import FromPandas
 from dask_expr.tests._util import _backend_library
 
@@ -340,3 +341,17 @@ def test_set_index_predicate_pushdown(df, pdf):
 
     result = query[(query.index > 5) & (query.y > -1)]
     assert_eq(result, pdf[(pdf.index > 5) & (pdf.y > -1)])
+
+
+def test_set_index_sort_values_one_partition(pdf):
+    df = from_pandas(pdf, sort=False)
+    query = df.sort_values("x").optimize(fuse=False)
+    assert query.divisions == (None, None)
+    assert_eq(pdf.sort_values("x"), query, sort_results=False)
+    assert len(divisions_lru) == 0
+
+    df = from_pandas(pdf, sort=False)
+    query = df.set_index("x").optimize(fuse=False)
+    assert query.divisions == (None, None)
+    assert_eq(pdf.set_index("x"), query)
+    assert len(divisions_lru) == 0

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import pytest
 from dask.dataframe.utils import assert_eq
 
@@ -344,6 +346,7 @@ def test_set_index_predicate_pushdown(df, pdf):
 
 
 def test_set_index_sort_values_one_partition(pdf):
+    divisions_lru.data = OrderedDict()
     df = from_pandas(pdf, sort=False)
     query = df.sort_values("x").optimize(fuse=False)
     assert query.divisions == (None, None)


### PR DESCRIPTION
This came up in tpch, there is no need to trigger a divisions computation if we are reduced to one partition anyway