### PR TITLE
Make repartition accept a callable for npartitions

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -415,20 +415,28 @@ class FrameBase(DaskMethodsMixin):
     ):
         """Repartition a collection
 
-        Exactly one of `divisions` or `npartitions` should be specified.
-        A ``ValueError`` will be raised when that is not the case.
+        Exactly one of `divisions`, `npartitions` or `partition_size` should be
+        specified. A ``ValueError`` will be raised when that is not the case.
 
         Parameters
         ----------
-        npartitions : int, optional
+        npartitions : int, Callable, optional
             Approximate number of partitions of output. The number of
             partitions used may be slightly lower than npartitions depending
             on data distribution, but will never be higher.
+            The Callable gets the number of partitions of the input as an argument
+            and should return an int.
         divisions : list, optional
             The "dividing lines" used to split the dataframe into partitions.
             For ``divisions=[0, 10, 50, 100]``, there would be three output partitions,
             where the new index contained [0, 10), [10, 50), and [50, 100), respectively.
             See https://docs.dask.org/en/latest/dataframe-design.html#partitions.
+        partition_size : str, optional
+            Max number of bytes of memory for each partition. Use numbers or strings
+            like 5MB. If specified npartitions and divisions will be ignored. Note that
+            the size reflects the number of bytes used as computed by
+            pandas.DataFrame.memory_usage, which will not necessarily match the size
+            when storing to disk.
         force : bool, default False
             Allows the expansion of the existing divisions.
             If False then the new divisions' lower and upper bounds must be

--- a/dask_expr/_repartition.py
+++ b/dask_expr/_repartition.py
@@ -21,9 +21,15 @@ from dask_expr._util import LRU
 class Repartition(Expr):
     """Abstract repartitioning expression"""
 
-    _parameters = ["frame", "n", "new_divisions", "force", "partition_size"]
+    _parameters = [
+        "frame",
+        "new_partitions",
+        "new_divisions",
+        "force",
+        "partition_size",
+    ]
     _defaults = {
-        "n": None,
+        "new_partitions": None,
         "new_divisions": None,
         "force": False,
         "partition_size": None,
@@ -35,7 +41,10 @@ class Repartition(Expr):
         return self.frame._meta
 
     def _divisions(self):
-        if self.n is not None or self.partition_size is not None:
+        if (
+            self.operand("new_partitions") is not None
+            or self.partition_size is not None
+        ):
             x = self.optimize(fuse=False)
             return x._divisions()
         return self.new_divisions
@@ -44,9 +53,9 @@ class Repartition(Expr):
         if type(self) != Repartition:
             # This lower logic should not be inherited
             return None
-        if self.n is not None:
-            if self._n < self.frame.npartitions:
-                return RepartitionToFewer(self.frame, self.n)
+        if self.operand("new_partitions") is not None:
+            if self.new_partitions < self.frame.npartitions:
+                return RepartitionToFewer(self.frame, self.operand("new_partitions"))
             else:
                 original_divisions = divisions = pd.Series(
                     self.frame.divisions
@@ -55,7 +64,7 @@ class Repartition(Expr):
                     is_datetime64_any_dtype(divisions.dtype)
                     or is_numeric_dtype(divisions.dtype)
                 ):
-                    npartitions = self._n
+                    npartitions = self.new_partitions
                     df = self.frame
                     if is_datetime64_any_dtype(divisions.dtype):
                         divisions = divisions.values.astype("float64")
@@ -87,7 +96,7 @@ class Repartition(Expr):
                     divisions = list(unique(divisions[:-1])) + [divisions[-1]]
                     return RepartitionDivisions(df, divisions, self.force)
                 else:
-                    return RepartitionToMore(self.frame, self.n)
+                    return RepartitionToMore(self.frame, self.operand("new_partitions"))
         elif self.new_divisions:
             if tuple(self.new_divisions) == self.frame.divisions:
                 return self.frame
@@ -106,23 +115,25 @@ class Repartition(Expr):
             return type(self)(self.frame[parent.operand("columns")], *self.operands[1:])
 
     @functools.cached_property
-    def _n(self):
+    def new_partitions(self):
         return (
-            self.n(self.frame.npartitions) if isinstance(self.n, Callable) else self.n
+            self.operand("new_partitions")(self.frame.npartitions)
+            if isinstance(self.operand("new_partitions"), Callable)
+            else self.operand("new_partitions")
         )
 
 
 class RepartitionToFewer(Repartition):
     """Reduce the partition count"""
 
-    _parameters = ["frame", "n"]
+    _parameters = ["frame", "new_partitions"]
 
     def _divisions(self):
         return tuple(self.frame.divisions[i] for i in self._partitions_boundaries)
 
     @functools.cached_property
     def _partitions_boundaries(self):
-        npartitions = self._n
+        npartitions = self.new_partitions
         npartitions_input = self.frame.npartitions
         assert npartitions_input > npartitions
 
@@ -151,7 +162,7 @@ class RepartitionToFewer(Repartition):
 class RepartitionToMore(Repartition):
     """Increase the partition count"""
 
-    _parameters = ["frame", "n"]
+    _parameters = ["frame", "new_partitions"]
 
     def _divisions(self):
         return (None,) * (1 + sum(self._nsplits))
@@ -159,7 +170,7 @@ class RepartitionToMore(Repartition):
     @functools.cached_property
     def _nsplits(self):
         df = self.frame
-        div, mod = divmod(self._n, df.npartitions)
+        div, mod = divmod(self.new_partitions, df.npartitions)
         nsplits = [div] * df.npartitions
         nsplits[-1] += mod
         if len(nsplits) != df.npartitions:

--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -217,7 +217,7 @@ class SimpleShuffle(PartitionsFiltered, ShuffleBackend):
 
         # Reduce partition count if necessary
         if npartitions_out < frame.npartitions:
-            frame = Repartition(frame, n=npartitions_out)
+            frame = Repartition(frame, new_partitions=npartitions_out)
 
         if partitioning_index != ["_partitions"]:
             if cls.lazy_hash_support:

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -171,6 +171,14 @@ def test_io_fusion_blockwise(tmpdir):
     assert df.npartitions == 1
 
 
+def test_repartition_io_fusion_blockwise(tmpdir):
+    pdf = lib.DataFrame({c: range(10) for c in "ab"})
+    dd.from_pandas(pdf, 10).to_parquet(tmpdir)
+    df = read_parquet(tmpdir)["a"]
+    df = df.repartition(npartitions=lambda x: max(x // 2, 1)).optimize()
+    assert df.npartitions == 2
+
+
 @pytest.mark.parametrize("fmt", ["parquet", "csv", "pandas"])
 def test_io_culling(tmpdir, fmt):
     pdf = lib.DataFrame({c: range(10) for c in "abcde"})


### PR DESCRIPTION
This is something we need after the IO fusion PR. 

Something like ``df.repartition(npartitions=df.npartitions // 2)`` might raise now because we might have squashed the partitions even more in the I/O layers, but you can do ``df.repartition(npartitions=lambda x: x // 2)`` to avoid this problem.