### PR TITLE
Update Fused keynames

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2453,11 +2453,12 @@ class Fused(Blockwise):
         return lines
 
     def __str__(self):
-        names = [expr._name.split("-")[0] for expr in self.exprs]
-        if len(names) > 3:
-            names = [names[0], f"{len(names) - 2}", names[-1]]
-        descr = "-".join(names)
-        return f"Fused-{descr}"
+        exprs = sorted(self.exprs, key=M._depth)
+        names = [expr._name.split("-")[0] for expr in exprs]
+        if len(names) > 4:
+            return names[0] + "-fused-" + names[-1]
+        else:
+            return "-".join(names)
 
     @functools.cached_property
     def _name(self):

--- a/dask_expr/tests/test_fusion.py
+++ b/dask_expr/tests/test_fusion.py
@@ -116,3 +116,11 @@ def test_fuse_broadcast_deps():
     query = df.merge(df2).merge(df3)
     assert len(query.optimize().__dask_graph__()) == 2
     assert_eq(query, pdf.merge(pdf2).merge(pdf3))
+
+
+def test_name(df):
+    out = (df["x"] + df["y"]) - 1
+    fused = optimize(out, fuse=True)
+    assert "pandas" in str(fused.expr)
+    assert "sub" in str(fused.expr)
+    assert str(fused.expr) == str(fused.expr).lower()


### PR DESCRIPTION
1.  Remove "Fused" from the beginning of the name.  This is mostly an internal detail that we care about, not something that most users care about I think.

2.  Sort expressions by depth, so that the first operation (like readparquet) is first and the last operation (like sum) is last.

    **Warning**, the `_depth` method is currently not very efficient

3.  Keep fused in the name, but now in the middle, where it's a bit less prominent

cc @phofl thoughts?