### PR TITLE
Refactor FusedIO to avoid duplicated tasks

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -800,9 +800,8 @@ class Expr:
             seen.add(expr._name)
 
             layers.append(expr._layer())
-            for operand in expr.operands:
-                if isinstance(operand, Expr):
-                    stack.append(operand)
+            for operand in expr.dependencies():
+                stack.append(operand)
 
         return toolz.merge(layers)
 

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -133,6 +133,9 @@ class FusedIO(BlockwiseIO):
     def _meta(self):
         return self.operand("expr")._meta
 
+    def dependencies(self):
+        return []
+
     @functools.cached_property
     def npartitions(self):
         return len(self._fusion_buckets)

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -166,9 +166,10 @@ def test_predicate_pushdown_compound(tmpdir):
 
 def test_io_fusion_blockwise(tmpdir):
     pdf = lib.DataFrame({c: range(10) for c in "abcdefghijklmn"})
-    dd.from_pandas(pdf, 2).to_parquet(tmpdir)
+    dd.from_pandas(pdf, 3).to_parquet(tmpdir)
     df = read_parquet(tmpdir)["a"].fillna(10).optimize()
     assert df.npartitions == 1
+    assert len(df.__dask_graph__()) == 1
 
 
 def test_repartition_io_fusion_blockwise(tmpdir):


### PR DESCRIPTION
This doesn't matter performance-wise but it creates a larger task graph than necessary that the scheduler will have to go through afterwards.