### PR TITLE
Support `split_out` for reductions using shuffling

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -803,12 +803,14 @@ class DataFrame(FrameBase):
     def memory_usage(self, deep=False, index=True):
         return new_collection(MemoryUsageFrame(self.expr, deep=deep, _index=index))
 
-    def drop_duplicates(self, subset=None, ignore_index=False):
+    def drop_duplicates(self, subset=None, ignore_index=False, split_out=None):
         # Fail early if subset is not valid, e.g. missing columns
         subset = _convert_to_list(subset)
         meta_nonempty(self._meta).drop_duplicates(subset=subset)
         return new_collection(
-            DropDuplicates(self.expr, subset=subset, ignore_index=ignore_index)
+            DropDuplicates(
+                self.expr, subset=subset, ignore_index=ignore_index, split_out=split_out
+            )
         )
 
     def dropna(self, how=no_default, subset=None, thresh=no_default):

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -803,7 +803,7 @@ class DataFrame(FrameBase):
     def memory_usage(self, deep=False, index=True):
         return new_collection(MemoryUsageFrame(self.expr, deep=deep, _index=index))
 
-    def drop_duplicates(self, subset=None, ignore_index=False, split_out=None):
+    def drop_duplicates(self, subset=None, ignore_index=False, split_out=1):
         # Fail early if subset is not valid, e.g. missing columns
         subset = _convert_to_list(subset)
         meta_nonempty(self._meta).drop_duplicates(subset=subset)
@@ -1052,8 +1052,10 @@ class Series(FrameBase):
     def unique(self):
         return new_collection(Unique(self.expr))
 
-    def drop_duplicates(self, ignore_index=False):
-        return new_collection(DropDuplicates(self.expr, ignore_index=ignore_index))
+    def drop_duplicates(self, ignore_index=False, split_out=1):
+        return new_collection(
+            DropDuplicates(self.expr, ignore_index=ignore_index, split_out=split_out)
+        )
 
     def dropna(self):
         return new_collection(expr.DropnaSeries(self.expr))

--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -80,6 +80,7 @@ class GroupByShuffleReduce(ShuffleReduce):
                 chunked,
                 self.split_by,
                 npartitions=shuffle_npartitions,
+                ignore_index=True,
             )
         else:
             shuffled = Shuffle(

--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -21,14 +21,8 @@ from dask.dataframe.groupby import (
 from dask.utils import M, is_index_like
 
 from dask_expr._collection import DataFrame, Index, Series, new_collection
-from dask_expr._expr import Expr, MapPartitions, Projection, RenameFrame, ResetIndex
-from dask_expr._reductions import (
-    Aggregate,
-    ApplyConcatApply,
-    Chunk,
-    Reduction,
-    ShuffleReduce,
-)
+from dask_expr._expr import Expr, MapPartitions, Projection
+from dask_expr._reductions import ApplyConcatApply, Chunk, Reduction
 
 
 def _as_dict(key, value):
@@ -51,70 +45,8 @@ class GroupByChunk(Chunk):
         return [self.frame, self.by]
 
 
-class GroupByShuffleReduce(ShuffleReduce):
-    def _lower(self):
-        from dask_expr._repartition import Repartition
-        from dask_expr._shuffle import SetIndexBlockwise, Shuffle, SortValues
-
-        assert self.split_by
-        split_every = getattr(self, "split_every", 0) or self.frame.npartitions
-
-        # Decompose ApplyConcatApply into Chunk + Shuffle + Aggregate
-        chunked = ResetIndex(self.frame, drop=False)
-
-        # TODO: Why do we need this band-aid?
-        map_columns = {col: str(col) for col in chunked.columns if col != str(col)}
-        unmap_columns = {v: k for k, v in map_columns.items()}
-        if map_columns:
-            chunked = RenameFrame(chunked, map_columns)
-
-        # Sort or shuffle
-        shuffle_npartitions = max(
-            chunked.npartitions // split_every,
-            self.split_out,
-        )
-        divisions = (None,) * (shuffle_npartitions + 1)
-        if self.sort:
-            # TODO: Use sorted divisions info
-            shuffled = SortValues(
-                chunked,
-                self.split_by,
-                npartitions=shuffle_npartitions,
-                ignore_index=True,
-            )
-        else:
-            shuffled = Shuffle(
-                chunked,
-                self.split_by,
-                shuffle_npartitions,
-                ignore_index=True,
-            )
-
-        if unmap_columns:
-            shuffled = RenameFrame(shuffled, unmap_columns)
-
-        # Set sorted/shuffled index and aggregate
-        shuffled = SetIndexBlockwise(shuffled, self.split_by, True, divisions)
-        result = Aggregate(
-            shuffled,
-            self.kind,
-            self.aggregate,
-            self.aggregate_kwargs,
-        )
-
-        # Convert to Series if necessary
-        if is_series_like(self._meta):
-            result = result[result.columns[0]]
-
-        # Repartition and return
-        if self.split_out < result.npartitions:
-            return Repartition(result, npartitions=self.split_out)
-        return result
-
-
 class GroupByApplyConcatApply(ApplyConcatApply):
     _chunk_cls = GroupByChunk
-    _shuffle_reduce_cls = GroupByShuffleReduce
 
     @functools.cached_property
     def _meta_chunk(self):
@@ -397,7 +329,6 @@ class ValueCounts(SingleAggregation):
 
 class GroupByReduction(Reduction):
     _chunk_cls = GroupByChunk
-    _shuffle_reduce_cls = GroupByShuffleReduce
 
     @property
     def _chunk_cls_args(self):

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -876,19 +876,24 @@ def test_astype_simplify(df, pdf):
     assert result._name == expected._name
 
 
-def test_drop_duplicates(df, pdf):
-    assert_eq(df.drop_duplicates(), pdf.drop_duplicates())
+@pytest.mark.parametrize("split_out", [1, True])
+def test_drop_duplicates(df, pdf, split_out):
+    assert_eq(df.drop_duplicates(split_out=split_out), pdf.drop_duplicates())
     assert_eq(
-        df.drop_duplicates(ignore_index=True), pdf.drop_duplicates(ignore_index=True)
+        df.drop_duplicates(ignore_index=True, split_out=split_out),
+        pdf.drop_duplicates(ignore_index=True),
     )
-    assert_eq(df.drop_duplicates(subset=["x"]), pdf.drop_duplicates(subset=["x"]))
-    assert_eq(df.x.drop_duplicates(), pdf.x.drop_duplicates())
+    assert_eq(
+        df.drop_duplicates(subset=["x"], split_out=split_out),
+        pdf.drop_duplicates(subset=["x"]),
+    )
+    assert_eq(df.x.drop_duplicates(split_out=split_out), pdf.x.drop_duplicates())
 
     with pytest.raises(KeyError, match="'a'"):
-        df.drop_duplicates(subset=["a"])
+        df.drop_duplicates(subset=["a"], split_out=split_out)
 
     with pytest.raises(TypeError, match="got an unexpected keyword argument"):
-        df.x.drop_duplicates(subset=["a"])
+        df.x.drop_duplicates(subset=["a"], split_out=split_out)
 
 
 def test_unique(df, pdf):

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -153,3 +153,35 @@ def test_groupby_index(pdf):
     result = df.groupby(df.index).agg({"y": "sum"})
     expected = pdf.groupby(pdf.index).agg({"y": "sum"})
     assert_eq(result, expected)
+
+
+@pytest.mark.parametrize("api", ["sum", "mean", "min", "max", "prod", "var", "std"])
+@pytest.mark.parametrize("sort", [True, False])
+@pytest.mark.parametrize("split_out", [1, 2])
+def test_groupby_single_agg_split_out(pdf, df, api, sort, split_out):
+    g = df.groupby("x", sort=sort)
+    agg = getattr(g, api)(split_out=split_out)
+
+    expect = getattr(pdf.groupby("x", sort=sort), api)()
+    assert_eq(agg, expect, sort_results=not sort)
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {"x": "count"},
+        {"x": ["count"]},
+        {"x": ["count"], "y": "mean"},
+        {"x": ["sum", "mean"]},
+        ["min", "mean"],
+        "sum",
+    ],
+)
+@pytest.mark.parametrize("sort", [True, False])
+@pytest.mark.parametrize("split_out", [1, 2])
+def test_groupby_agg_split_out(pdf, df, spec, sort, split_out):
+    g = df.groupby("x", sort=sort)
+    agg = g.agg(spec, split_out=split_out)
+
+    expect = pdf.groupby("x", sort=sort).agg(spec)
+    assert_eq(agg, expect, sort_results=not sort)


### PR DESCRIPTION
Introduces a new `ShuffleReduce` expression to support `split_out>1` and `sort=True` within groupby aggregations. This PR also adds support for `split_out > 1` for `drop_duplicates`.

**Notes**:
- This PR introduces the convention that `split_out=True` means that the partition count will be preserved.
- This PR  supersedes #248
- It seems reasonable to use `split_out=True` as the default for `drop_duplicates`. However, the shuffle-algorithm does not preserve the original ordering of unique rows. It is unclear to me if this will be problematic for users?