### PR TITLE
Allow `pandas-1.5.3` but warn the user on import

### DIFF
--- a/dask_expr/__init__.py
+++ b/dask_expr/__init__.py
@@ -2,3 +2,12 @@ from dask_expr import _version, datasets
 from dask_expr._collection import *
 
 __version__ = _version.get_versions()["version"]
+
+from dask.dataframe._compat import PANDAS_GE_200
+
+if not PANDAS_GE_200:
+    warnings.warn(
+        "The installed Pandas version is not recommended for "
+        "`dask_expr`. Please update to `pandas>=2` if possible."
+        "\nRAPIDS users can ignore this warning."
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.9"
 dependencies = [
     "dask >= 2023.09.2",
     "pyarrow",
-    "pandas >= 2",
+    "pandas >= 1.5.3",
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
I've been running into some pain while setting up an environment to test/benchmark dask-expr + cudf. Most of this pain is related to the fact that dask-expr is pinned to `pandas>=2`. 

This PR proposes that we adjust the pin to `pandas>=1.5.3`, but warn the user (on import) if the version is `<2.0.0`. E.g.

```
UserWarning: The installed Pandas version is not recommended for `dask_expr`. Please update to `pandas>=2` if possible.
  RAPIDS users can ignore this warning.
```

My hope is that users will only pick up `pandas<2` when they are building an environment with `cudf`, but I like having the warning "just in case".