### PR TITLE
Make are_co_algined less reliant on divisions

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2257,14 +2257,18 @@ def non_blockwise_ancestors(expr):
 
 def are_co_aligned(*exprs):
     """Do inputs come from different parents, modulo blockwise?"""
-    exprs = [expr for expr in exprs if not is_broadcastable(expr)]
     ancestors = [set(non_blockwise_ancestors(e)) for e in exprs]
     unique_ancestors = {
         # Account for column projection within IO expressions
         _tokenize_partial(item, ["columns", "_series"])
         for item in flatten(ancestors, container=set)
     }
-    return len(unique_ancestors) <= 1
+    if len(unique_ancestors) <= 1:
+        return True
+    exprs_except_broadcast = [expr for expr in exprs if not is_broadcastable(expr)]
+    if len(exprs_except_broadcast) < len(exprs):
+        return are_co_aligned(*exprs_except_broadcast)
+    return False
 
 
 ## Utilites for Expr fusion

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2265,6 +2265,8 @@ def are_co_aligned(*exprs):
     }
     if len(unique_ancestors) <= 1:
         return True
+    # We tried avoiding an `npartitions` check above, but
+    # now we need to consider "broadcastable" expressions.
     exprs_except_broadcast = [expr for expr in exprs if not is_broadcastable(expr)]
     if len(exprs_except_broadcast) < len(exprs):
         return are_co_aligned(*exprs_except_broadcast)


### PR DESCRIPTION
cc @rjzamora 


This *should* fix the problem with statistics collection

I think that we actually don't run into the broadcast able case very often because the more likely path is that we have the same root