### PR TITLE
Remove ops that are not in parameters from tokenize_partial

### DIFF
--- a/dask_expr/_util.py
+++ b/dask_expr/_util.py
@@ -57,13 +57,13 @@ def _tokenize_partial(expr, ignore: list | None = None) -> str:
     # Helper function to "tokenize" the operands
     # that are not in the `ignore` list
     ignore = ignore or []
-    return _tokenize_deterministic(
-        *[
-            op
-            for i, op in enumerate(expr.operands)
-            if i >= len(expr._parameters) or expr._parameters[i] not in ignore
-        ]
-    )
+    ops = []
+    for i, op in enumerate(expr.operands):
+        if i >= len(expr._parameters):
+            continue
+        elif expr._parameters[i] not in ignore:
+            ops.append(op)
+    return _tokenize_deterministic(*ops)
 
 
 class LRU(UserDict[K, V]):


### PR DESCRIPTION
cc @rjzamora 

I'd rather include those than include them. We don't care about those at the moment, we can still add an option if we want them at some point, but they cause trouble with the multi-column assign