### PR TITLE
Fix bug in IO fusion layer if merge is directly on top of it

### DIFF
--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -131,7 +131,7 @@ class BlockwiseIO(Blockwise, IO):
             return
         if isinstance(parent, FusedIO):
             return
-        return type(parent)(FusedIO(self), *parent.operands[1:])
+        return parent.substitute(self, FusedIO(self))
 
 
 class FusedIO(BlockwiseIO):

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -184,6 +184,21 @@ def test_repartition_io_fusion_blockwise(tmpdir):
     assert df.npartitions == 2
 
 
+def test_io_fusion_merge(tmpdir):
+    pdf = lib.DataFrame({c: range(10) for c in "ab"})
+    pdf2 = lib.DataFrame({c: range(10) for c in "uvwxyz"})
+    dd.from_pandas(pdf, 10).to_parquet(tmpdir)
+    dd.from_pandas(pdf2, 10).to_parquet(tmpdir + "x")
+    df = read_parquet(tmpdir)
+    df2 = read_parquet(tmpdir + "x")
+    result = df.merge(df2, left_on="a", right_on="w")[["a", "b", "u"]]
+    assert_eq(
+        result,
+        pdf.merge(pdf2, left_on="a", right_on="w")[["a", "b", "u"]],
+        check_index=False,
+    )
+
+
 @pytest.mark.parametrize("fmt", ["parquet", "csv", "pandas"])
 def test_io_culling(tmpdir, fmt):
     pdf = lib.DataFrame({c: range(10) for c in "abcde"})


### PR DESCRIPTION
That was an oversight. There is no guarantee that ``self`` is the first operand, so substitute is needed