### PR TITLE
Fix multi-column ``SetIndexBlockwise``

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -883,6 +883,11 @@ class DataFrame(FrameBase):
         upsample: float = 1.0,
         partition_size: float = 128e6,
     ):
+        if isinstance(other, list):
+            if any([isinstance(c, FrameBase) for c in other]):
+                raise TypeError("List[FrameBase] not supported by set_index")
+            elif not sorted:
+                raise NotImplementedError("Multi-column set_index requires sorted=True")
         if isinstance(other, DataFrame):
             raise TypeError("other can't be of type DataFrame")
         if isinstance(other, Series):

--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -50,7 +50,7 @@ from dask_expr._reductions import (
     ValueCounts,
 )
 from dask_expr._repartition import Repartition, RepartitionToFewer
-from dask_expr._util import LRU
+from dask_expr._util import LRU, _convert_to_list
 
 
 class Shuffle(Expr):
@@ -1050,7 +1050,7 @@ class SetIndexBlockwise(Blockwise):
     def _simplify_up(self, parent):
         if isinstance(parent, Projection):
             columns = parent.columns + (
-                [self.other] if not isinstance(self.other, Expr) else []
+                _convert_to_list(self.other) if not isinstance(self.other, Expr) else []
             )
             if self.frame.columns == columns:
                 return

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -177,6 +177,12 @@ def test_set_index_sorted(pdf):
     expected = df[["y", "z"]].set_index(["y", "z"], sorted=True)[[]].simplify()
     assert result._name == expected._name
 
+    with pytest.raises(TypeError, match="not supported by set_index"):
+        df.set_index([df["y"]], sorted=True)
+
+    with pytest.raises(NotImplementedError, match="requires sorted=True"):
+        df.set_index(["y", "z"], sorted=False)
+
 
 def test_set_index_pre_sorted(pdf):
     pdf = pdf.sort_values(by="y", ignore_index=True)

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -171,6 +171,12 @@ def test_set_index_sorted(pdf):
     expected = df[["x", "y"]].set_index("y", sorted=True)["x"].simplify()
     assert result._name == expected._name
 
+    q = df.set_index(["y", "z"], sorted=True)[[]]
+    assert_eq(q, pdf.set_index(["y", "z"])[[]])
+    result = q.optimize(fuse=False)
+    expected = df[["y", "z"]].set_index(["y", "z"], sorted=True)[[]].simplify()
+    assert result._name == expected._name
+
 
 def test_set_index_pre_sorted(pdf):
     pdf = pdf.sort_values(by="y", ignore_index=True)


### PR DESCRIPTION
Came across this while debugging other remaining `split_out>1` reduction bugs.