### PR TITLE
Add ``from_map`` API for custom collection creation

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -1265,7 +1265,7 @@ def from_map(
     divisions=None,
     label=None,
     token=None,
-    enforce_metadata=False,
+    enforce_metadata=True,
     allow_projection=True,
     **kwargs,
 ):
@@ -1273,8 +1273,7 @@ def from_map(
     from dask_expr.io import FromMap, FromMapProjectable
 
     if token is not None:
-        raise NotImplementedError()
-    if enforce_metadata:
+        # This option doens't really make sense in dask-expr
         raise NotImplementedError()
 
     if allow_projection:
@@ -1304,6 +1303,7 @@ def from_map(
                 args,
                 kwargs,
                 meta,
+                enforce_metadata,
                 divisions,
                 label,
             )
@@ -1316,6 +1316,7 @@ def from_map(
                 args,
                 kwargs,
                 meta,
+                enforce_metadata,
                 divisions,
                 label,
             )

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -1254,3 +1254,36 @@ def concat(
             *[df.expr for df in dfs],
         )
     )
+
+
+def from_map(
+    func,
+    *iterables,
+    args=None,
+    meta=no_default,
+    divisions=None,
+    label=None,
+    token=None,
+    enforce_metadata=False,
+    **kwargs,
+):
+    from dask_expr.io import FromMap
+
+    if token is not None:
+        raise NotImplementedError()
+    if enforce_metadata:
+        raise NotImplementedError()
+
+    args = [] if args is None else args
+    kwargs = {} if kwargs is None else kwargs
+    return new_collection(
+        FromMap(
+            func,
+            iterables,
+            args,
+            kwargs,
+            meta,
+            divisions,
+            label,
+        )
+    )

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -1264,17 +1264,16 @@ def from_map(
     meta=no_default,
     divisions=None,
     label=None,
-    token=None,
-    enforce_metadata=True,
+    enforce_metadata=False,
     allow_projection=True,
     **kwargs,
 ):
     """Create a dask-expr collection from a custom function map"""
     from dask_expr.io import FromMap, FromMapProjectable
 
-    if token is not None:
-        # This option doens't really make sense in dask-expr
-        raise NotImplementedError()
+    if "token" in kwargs:
+        # This option doesn't really make sense in dask-expr
+        raise NotImplementedError("dask_expr does not support a token argument.")
 
     if allow_projection:
         from dask.dataframe.io.utils import DataFrameIOFunction

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -1265,9 +1265,10 @@ def from_map(
     label=None,
     token=None,
     enforce_metadata=False,
+    allow_projection=False,
     **kwargs,
 ):
-    from dask_expr.io import FromMap
+    from dask_expr.io import FromMap, FromMapProjectable
 
     if token is not None:
         raise NotImplementedError()
@@ -1276,14 +1277,29 @@ def from_map(
 
     args = [] if args is None else args
     kwargs = {} if kwargs is None else kwargs
-    return new_collection(
-        FromMap(
-            func,
-            iterables,
-            args,
-            kwargs,
-            meta,
-            divisions,
-            label,
+    if allow_projection:
+        columns = kwargs.pop("columns", None)
+        return new_collection(
+            FromMapProjectable(
+                func,
+                iterables,
+                columns,
+                args,
+                kwargs,
+                meta,
+                divisions,
+                label,
+            )
         )
-    )
+    else:
+        return new_collection(
+            FromMap(
+                func,
+                iterables,
+                args,
+                kwargs,
+                meta,
+                divisions,
+                label,
+            )
+        )

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -197,7 +197,7 @@ class FromMap(PartitionsFiltered, BlockwiseIO):
     ]
     _defaults = {
         "user_meta": no_default,
-        "enforce_metadata": True,
+        "enforce_metadata": False,
         "user_divisions": None,
         "label": None,
         "_partitions": None,
@@ -209,7 +209,11 @@ class FromMap(PartitionsFiltered, BlockwiseIO):
         if self.label:
             return self.label + "-" + _tokenize_deterministic(*self.operands)
         else:
-            return "from_map-" + _tokenize_deterministic(*self.operands)
+            return (
+                funcname(self.func).lower()
+                + "-"
+                + _tokenize_deterministic(*self.operands)
+            )
 
     @functools.cached_property
     def _meta(self):
@@ -226,10 +230,6 @@ class FromMap(PartitionsFiltered, BlockwiseIO):
         else:
             npartitions = len(self.iterables[0])
             return (None,) * (npartitions + 1)
-
-    # @property
-    # def kwargs(self):
-    #     return self.operand("kwargs")
 
     @property
     def apply_func(self):
@@ -274,7 +274,7 @@ class FromMapProjectable(FromMap):
     ]
     _defaults = {
         "user_meta": no_default,
-        "enforce_metadata": True,
+        "enforce_metadata": False,
         "user_divisions": None,
         "label": None,
         "_partitions": None,

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -206,14 +206,14 @@ class FromMap(PartitionsFiltered, BlockwiseIO):
 
     @functools.cached_property
     def _name(self):
-        if self.label:
-            return self.label + "-" + _tokenize_deterministic(*self.operands)
-        else:
+        if self.label is None:
             return (
                 funcname(self.func).lower()
                 + "-"
                 + _tokenize_deterministic(*self.operands)
             )
+        else:
+            return self.label + "-" + _tokenize_deterministic(*self.operands)
 
     @functools.cached_property
     def _meta(self):
@@ -303,7 +303,7 @@ class FromMapProjectable(FromMap):
     def kwargs(self):
         options = self.operand("kwargs")
         if self.columns_operand:
-            options["columns"] = self.columns_operand
+            options["columns"] = self.columns_operand.copy()
         return options
 
     @functools.cached_property

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -303,7 +303,8 @@ class FromMapProjectable(FromMap):
     def kwargs(self):
         options = self.operand("kwargs")
         if self.columns_operand:
-            options["columns"] = self.columns_operand.copy()
+            options = options.copy()
+            options["columns"] = self.columns_operand
         return options
 
     @functools.cached_property

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -414,6 +414,9 @@ def test_from_map(tmpdir, meta, label, allow_projection, enforce_metadata):
     assert_eq(df[["a"]], pdf[["a"]], check_index=False)
     assert_eq(df[["a", "b"]], pdf[["a", "b"]], check_index=False)
 
+    if label:
+        assert df.expr._name.startswith(label)
+
     if allow_projection:
         got = df[["a", "b"]].optimize(fuse=False)
         assert isinstance(got.expr, FromMap)

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -396,8 +396,10 @@ def test_from_map_projectable(tmpdir):
     files = sorted(glob.glob(str(tmpdir) + "/*.parquet"))
 
     df = from_map(lib.read_parquet, files)
-    assert_eq(df, pdf, check_index=False)
-    assert_eq(df["a"], pdf["a"], check_index=False)
+    # assert_eq(df, pdf, check_index=False)
+    # assert_eq(df["a"], pdf["a"], check_index=False)
+    # import pdb; pdb.set_trace()
+    df[["a"]].compute()
     assert_eq(df[["a"]], pdf[["a"]], check_index=False)
     assert_eq(df[["a", "b"]], pdf[["a", "b"]], check_index=False)
 

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -380,13 +380,13 @@ def test_from_map(tmpdir):
     dd.from_pandas(pdf, 3).to_parquet(tmpdir, write_index=False)
     files = sorted(glob.glob(str(tmpdir) + "/*.parquet"))
 
-    df = from_map(lib.read_parquet, files)
+    df = from_map(lib.read_parquet, files, allow_projection=False)
     assert_eq(df, pdf, check_index=False)
 
-    dfa = from_map(lib.read_parquet, files, columns="a")
+    dfa = from_map(lib.read_parquet, files, columns="a", allow_projection=False)
     assert_eq(dfa, pdf[["a"]], check_index=False)
 
-    dfab = from_map(lib.read_parquet, files, columns=["a", "b"])
+    dfab = from_map(lib.read_parquet, files, columns=["a", "b"], allow_projection=False)
     assert_eq(dfab, pdf[["a", "b"]], check_index=False)
 
 
@@ -395,11 +395,11 @@ def test_from_map_projectable(tmpdir):
     dd.from_pandas(pdf, 3).to_parquet(tmpdir, write_index=False)
     files = sorted(glob.glob(str(tmpdir) + "/*.parquet"))
 
-    df = from_map(lib.read_parquet, files, allow_projection=True)
+    df = from_map(lib.read_parquet, files)
     assert_eq(df, pdf, check_index=False)
     assert_eq(df["a"], pdf["a"], check_index=False)
     assert_eq(df[["a"]], pdf[["a"]], check_index=False)
-    assert_eq(df["a", "b"], pdf["a", "b"], check_index=False)
+    assert_eq(df[["a", "b"]], pdf[["a", "b"]], check_index=False)
 
     got = df[["a", "b"]].optimize(fuse=False)
     assert isinstance(got.expr, FromMap)

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -375,23 +375,6 @@ def test_combine_similar_no_projection_on_one_branch(tmpdir):
     assert_eq(df, pdf)
 
 
-# @pytest.mark.parametrize("enforce_metadata", [True, False])
-# def test_from_map(tmpdir, enforce_metadata):
-#     pdf = lib.DataFrame({c: range(10) for c in "abcdefghijklmn"})
-#     dd.from_pandas(pdf, 3).to_parquet(tmpdir, write_index=False)
-#     files = sorted(glob.glob(str(tmpdir) + "/*.parquet"))
-#     options = {"enforce_metadata": enforce_metadata, "allow_projection": False}
-
-#     df = from_map(lib.read_parquet, files, **options)
-#     assert_eq(df, pdf, check_index=False)
-
-#     dfa = from_map(lib.read_parquet, files, columns="a", **options)
-#     assert_eq(dfa, pdf[["a"]], check_index=False)
-
-#     dfab = from_map(lib.read_parquet, files, columns=["a", "b"], **options)
-#     assert_eq(dfab, pdf[["a", "b"]], check_index=False)
-
-
 @pytest.mark.parametrize("meta", [True, False])
 @pytest.mark.parametrize("label", [None, "foo"])
 @pytest.mark.parametrize("allow_projection", [True, False])

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -396,10 +396,8 @@ def test_from_map_projectable(tmpdir):
     files = sorted(glob.glob(str(tmpdir) + "/*.parquet"))
 
     df = from_map(lib.read_parquet, files)
-    # assert_eq(df, pdf, check_index=False)
-    # assert_eq(df["a"], pdf["a"], check_index=False)
-    # import pdb; pdb.set_trace()
-    df[["a"]].compute()
+    assert_eq(df, pdf, check_index=False)
+    assert_eq(df["a"], pdf["a"], check_index=False)
     assert_eq(df[["a"]], pdf[["a"]], check_index=False)
     assert_eq(df[["a", "b"]], pdf[["a", "b"]], check_index=False)
 

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -375,27 +375,31 @@ def test_combine_similar_no_projection_on_one_branch(tmpdir):
     assert_eq(df, pdf)
 
 
-def test_from_map(tmpdir):
+@pytest.mark.parametrize("enforce_metadata", [True, False])
+def test_from_map(tmpdir, enforce_metadata):
     pdf = lib.DataFrame({c: range(10) for c in "abcdefghijklmn"})
     dd.from_pandas(pdf, 3).to_parquet(tmpdir, write_index=False)
     files = sorted(glob.glob(str(tmpdir) + "/*.parquet"))
+    options = {"enforce_metadata": enforce_metadata, "allow_projection": False}
 
-    df = from_map(lib.read_parquet, files, allow_projection=False)
+    df = from_map(lib.read_parquet, files, **options)
     assert_eq(df, pdf, check_index=False)
 
-    dfa = from_map(lib.read_parquet, files, columns="a", allow_projection=False)
+    dfa = from_map(lib.read_parquet, files, columns="a", **options)
     assert_eq(dfa, pdf[["a"]], check_index=False)
 
-    dfab = from_map(lib.read_parquet, files, columns=["a", "b"], allow_projection=False)
+    dfab = from_map(lib.read_parquet, files, columns=["a", "b"], **options)
     assert_eq(dfab, pdf[["a", "b"]], check_index=False)
 
 
-def test_from_map_projectable(tmpdir):
+@pytest.mark.parametrize("enforce_metadata", [True, False])
+def test_from_map_projectable(tmpdir, enforce_metadata):
     pdf = lib.DataFrame({c: range(10) for c in "abcdefghijklmn"})
     dd.from_pandas(pdf, 3).to_parquet(tmpdir, write_index=False)
     files = sorted(glob.glob(str(tmpdir) + "/*.parquet"))
+    options = {"enforce_metadata": enforce_metadata, "allow_projection": True}
 
-    df = from_map(lib.read_parquet, files)
+    df = from_map(lib.read_parquet, files, **options)
     assert_eq(df, pdf, check_index=False)
     assert_eq(df["a"], pdf["a"], check_index=False)
     assert_eq(df[["a"]], pdf[["a"]], check_index=False)


### PR DESCRIPTION
The `dask.dataframe.from_map` API[ is a useful way to create a DataFrame collection](https://blog.dask.org/2023/04/12/from-map) using specialized logic or from unsupported file formats. It is also a reasonable way for users to implement a custom `read_parquet` API.

Key differences between the `dask.dataframe` and  `dask_expr` implementations:

- The `token` argument is not supported, because we need to have complete control over tokenization in dask-expr
- The `DataFrameIOFunction` protocol is not supported, because dask-expr makes it **much** easier to support column projection by more-convenient means. In the dask-expr implementation, we assume that the user wants column projection if `inspect.signature` reveals that `func` supports a `"columns"` argument. If the user has such an argument, but **doesn't** want column projection, they can just specify `allow_projection=False`.