### PR TITLE
Fix precedence issue between columns and index in merge

### DIFF
--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -82,11 +82,13 @@ class Shuffle(Expr):
         "ignore_index",
         "backend",
         "options",
+        "index_shuffle",
     ]
     _defaults = {
         "ignore_index": False,
         "backend": None,
         "options": None,
+        "index_shuffle": None,
     }
     _is_length_preserving = True
 
@@ -215,6 +217,7 @@ class SimpleShuffle(PartitionsFiltered, ShuffleBackend):
         npartitions_out = expr.npartitions_out
         ignore_index = expr.ignore_index
         options = expr.options
+        index_shuffle = expr.index_shuffle
 
         # Normalize partitioning_index
         if isinstance(partitioning_index, str):
@@ -233,7 +236,7 @@ class SimpleShuffle(PartitionsFiltered, ShuffleBackend):
                 # Don't need to assign "_partitions" column
                 # if we are shuffling on a list of columns
                 nset = set(partitioning_index)
-                if nset & set(frame.columns) == nset:
+                if nset & set(frame.columns) == nset and not index_shuffle:
                     return cls(
                         frame,
                         partitioning_index,
@@ -248,6 +251,7 @@ class SimpleShuffle(PartitionsFiltered, ShuffleBackend):
                 partitioning_index,
                 "_partitions",
                 npartitions_out,
+                index_shuffle,
             )
         else:
             index_added = frame
@@ -615,12 +619,23 @@ class AssignPartitioningIndex(Blockwise):
         Number of partitions after repartitioning is finished.
     """
 
-    _parameters = ["frame", "partitioning_index", "index_name", "npartitions_out"]
+    _parameters = [
+        "frame",
+        "partitioning_index",
+        "index_name",
+        "npartitions_out",
+        "assign_index",
+    ]
 
     @staticmethod
-    def operation(df, index, name: str, npartitions: int):
+    def operation(df, index, name: str, npartitions: int, assign_index):
         """Construct a hash-based partitioning index"""
-        index = _select_columns_or_index(df, index)
+        if assign_index:
+            index = df[[]]
+            index["_index"] = df.index
+        else:
+            index = _select_columns_or_index(df, index)
+
         if isinstance(index, (str, list, tuple)):
             # Assume column selection from df
             index = [index] if isinstance(index, str) else list(index)

--- a/dask_expr/tests/test_distributed.py
+++ b/dask_expr/tests/test_distributed.py
@@ -73,6 +73,24 @@ async def test_self_merge_p2p_shuffle(c, s, a, b):
 
 
 @gen_cluster(client=True)
+@pytest.mark.parametrize("shuffle", ["tasks", "disk", "p2p"])
+async def test_merge_index_precedence(c, s, a, b, shuffle):
+    pdf = lib.DataFrame(
+        {"a": [1, 2, 3, 4, 5, 6]}, index=lib.Index([6, 5, 4, 3, 2, 1], name="a")
+    )
+    pdf2 = lib.DataFrame(
+        {"b": [1, 2, 3, 4, 5, 6]}, index=lib.Index([1, 2, 7, 4, 5, 6], name="a")
+    )
+    df = from_pandas(pdf, npartitions=2, sort=False)
+    df2 = from_pandas(pdf2, npartitions=3, sort=False)
+
+    result = df.join(df2, shuffle_backend=shuffle)
+    x = await c.compute(result)
+    # assert result.npartitions == 6
+    lib.testing.assert_frame_equal(x.sort_index(ascending=False), pdf.join(pdf2))
+
+
+@gen_cluster(client=True)
 async def test_merge_p2p_shuffle_reused_dataframe_with_different_parameters(c, s, a, b):
     pdf1 = lib.DataFrame({"a": range(100), "b": range(0, 200, 2)})
     pdf2 = lib.DataFrame({"x": range(200), "y": [1, 2, 3, 4] * 50})


### PR DESCRIPTION
We are currently taking the column when the name collides even if index merge is set to True