### PR TITLE
Make repartition function work for duplicates

### DIFF
--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -480,7 +480,6 @@ class FromPandasDivisions(FromPandas):
             else:
                 # get_indexer for doesn't support method
                 indexer = np.searchsorted(data.index.values, key, side="left")
-                # indexer -= 1
             indexer[-1] = len(data)
             _division_info_cache[key] = key, indexer
         return _division_info_cache[key]

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -4,6 +4,7 @@ import functools
 import math
 import operator
 
+import numpy as np
 from dask.dataframe import methods
 from dask.dataframe.core import apply_and_enforce, is_dataframe_like, make_meta
 from dask.dataframe.io.io import sorted_division_locations
@@ -474,7 +475,12 @@ class FromPandasDivisions(FromPandas):
         _division_info_cache = self.frame._division_info
         if key not in _division_info_cache:
             data = self.frame._data
-            indexer = data.index.get_indexer(key, method="bfill")
+            if data.index.is_unique:
+                indexer = data.index.get_indexer(key, method="bfill")
+            else:
+                # get_indexer for doesn't support method
+                indexer = np.searchsorted(data.index.values, key, side="left")
+                # indexer -= 1
             indexer[-1] = len(data)
             _division_info_cache[key] = key, indexer
         return _division_info_cache[key]

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -456,3 +456,12 @@ def test_from_pandas_divisions():
 
     df = repartition(df, divisions=(1, 3, 8), force=True)
     assert_eq(df, pdf.sort_index())
+
+
+def test_from_pandas_divisions_duplicated():
+    pdf = lib.DataFrame({"a": 1}, index=[1, 2, 3, 4, 5, 5, 5, 6, 8])
+    df = repartition(pdf, (1, 5, 7, 10))
+    assert_eq(df, pdf)
+    assert_eq(df.partitions[0], pdf.loc[1:4])
+    assert_eq(df.partitions[1], pdf.loc[5:6])
+    assert_eq(df.partitions[2], pdf.loc[8:])


### PR DESCRIPTION
``get_indexer`` uses a hash table and is much faster, but it doesn't work for duplicates