### PR TITLE
Change default parquet compression format from Snappy to LZ4

### DIFF
--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -173,7 +173,7 @@ class ToParquetBarrier(Expr):
 def to_parquet(
     df,
     path,
-    compression="snappy",
+    compression="lz4",
     write_index=True,
     append=False,
     overwrite=False,


### PR DESCRIPTION
Snappy's status as default is maybe just due to history.  Snappy had better Java support and LZ4 wasn't always available in systems like Spark.  Today Spark and other systems support LZ4 as well, and LZ4 generally performs a bit better, especially on decompression.

This is a significant change, but I think the only reason not to do it is historical, which I think maybe isn't a good enough reason these days.