### PR TITLE
Raise in `to_numeric` if `arg` is anything other than a `Series`

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -1518,4 +1518,6 @@ def pivot_table(df, index, columns, values, aggfunc="mean"):
 
 
 def to_numeric(arg, errors="raise", downcast=None):
+    if not isinstance(arg, Series):
+        raise TypeError("arg must be a Series")
     return new_collection(ToNumeric(frame=arg.expr, errors=errors, downcast=downcast))

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -374,8 +374,11 @@ def test_to_numeric(pdf, df):
     pdf.x = pdf.x.astype("str")
     expected = lib.to_numeric(pdf.x)
     df.x = df.x.astype("str")
-    result = to_numeric(df.x, downcast=None)
+    result = to_numeric(df.x)
     assert_eq(result, expected)
+
+    with pytest.raises(TypeError, match="arg must be a Series"):
+        to_numeric("1.0")
 
 
 def test_drop_not_implemented(pdf, df):


### PR DESCRIPTION
Fail early, fail explicitly