### PR TITLE
Fix meta for reduction scalars

### DIFF
--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -389,6 +389,8 @@ class ApplyConcatApply(Expr):
 
         meta = combine([meta], **combine_kwargs)
         meta = aggregate([meta], **self.aggregate_kwargs)
+        if is_scalar(meta):
+            return make_meta(type(meta))
         return make_meta(meta)
 
     def _divisions(self):

--- a/dask_expr/tests/test_reductions.py
+++ b/dask_expr/tests/test_reductions.py
@@ -22,12 +22,8 @@ def test_monotonic():
         assert assert_eq(
             df[c].is_monotonic_increasing,
             pdf[c].is_monotonic_increasing,
-            # https://github.com/dask/dask/pull/10671
-            check_dtype=False,
         )
         assert assert_eq(
             df[c].is_monotonic_decreasing,
             pdf[c].is_monotonic_decreasing,
-            # https://github.com/dask/dask/pull/10671
-            check_dtype=False,
         )


### PR DESCRIPTION
So, it turns out that https://github.com/dask/dask/pull/10671 is not necessarily a problem. The problem why the reduction test originally failed is because the `Scalar` object had a python bool as it's meta instead of a numpy bool. Dask's assert logic has a special path for numpy dtypes that implements a more forgiving equality check I ran into here.

I suspect this is something we'll run into many times when comparing with the dask/dask test suite. This feels like something `make_meta` should deal with already properly. I'll poke around dask/dask if we can fix it at the source.