### PR TITLE
Align repartition signatures

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -495,7 +495,7 @@ class FrameBase(DaskMethodsMixin):
         return new_collection(new_expr)
 
     def repartition(
-        self, npartitions=None, divisions=None, force=False, partition_size=None
+        self, divisions=None, npartitions=None, partition_size=None, force=False
     ):
         """Repartition a collection
 
@@ -504,17 +504,17 @@ class FrameBase(DaskMethodsMixin):
 
         Parameters
         ----------
+        divisions : list, optional
+            The "dividing lines" used to split the dataframe into partitions.
+            For ``divisions=[0, 10, 50, 100]``, there would be three output partitions,
+            where the new index contained [0, 10), [10, 50), and [50, 100), respectively.
+            See https://docs.dask.org/en/latest/dataframe-design.html#partitions.
         npartitions : int, Callable, optional
             Approximate number of partitions of output. The number of
             partitions used may be slightly lower than npartitions depending
             on data distribution, but will never be higher.
             The Callable gets the number of partitions of the input as an argument
             and should return an int.
-        divisions : list, optional
-            The "dividing lines" used to split the dataframe into partitions.
-            For ``divisions=[0, 10, 50, 100]``, there would be three output partitions,
-            where the new index contained [0, 10), [10, 50), and [50, 100), respectively.
-            See https://docs.dask.org/en/latest/dataframe-design.html#partitions.
         partition_size : str, optional
             Max number of bytes of memory for each partition. Use numbers or strings
             like 5MB. If specified npartitions and divisions will be ignored. Note that

--- a/dask_expr/tests/test_distributed.py
+++ b/dask_expr/tests/test_distributed.py
@@ -132,7 +132,9 @@ async def test_merge_p2p_shuffle_reused_dataframe_with_different_parameters(c, s
     out = (
         ddf1.merge(ddf2, left_on="a", right_on="x", shuffle_backend="p2p")
         # Vary the number of output partitions for the shuffles of dd2
-        .repartition(20).merge(ddf2, left_on="b", right_on="x", shuffle_backend="p2p")
+        .repartition(npartitions=20).merge(
+            ddf2, left_on="b", right_on="x", shuffle_backend="p2p"
+        )
     )
     # Generate unique shuffle IDs if the input frame is the same but parameters differ
     assert sum(id_from_key(k) is not None for k in out.dask) == 4
@@ -272,12 +274,12 @@ def test_merge_combine_similar_squash_merges(add_repartition):
             df2 = df2[df2.m > 1]
             df3 = df3[df3.x > 1]
             if add_repartition:
-                df = df.repartition(df.npartitions // 2)
-                df2 = df2.repartition(df2.npartitions // 2)
+                df = df.repartition(npartitions=df.npartitions // 2)
+                df2 = df2.repartition(npartitions=df2.npartitions // 2)
             q = df.merge(df2, left_on="a", right_on="m")
             if add_repartition:
-                df3 = df3.repartition(df3.npartitions // 2)
-                q = q.repartition(q.npartitions // 2)
+                df3 = df3.repartition(npartitions=df3.npartitions // 2)
+                q = q.repartition(npartitions=q.npartitions // 2)
             q = q.merge(df3, left_on="n", right_on="x")
             q["revenue"] = q.y * (1 - q.z)
             result = q[["x", "n", "o", "revenue"]]


### PR DESCRIPTION
The signature difference seems like a unnecessary difference between dask/dask and us