### PR TITLE
Absorb kwargs in aggregate for now

### DIFF
--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -1189,7 +1189,7 @@ class GroupBy:
             result = result[result.columns[0]]
         return result
 
-    def aggregate(self, arg=None, split_every=8, split_out=None):
+    def aggregate(self, arg=None, split_every=8, split_out=None, **kwargs):
         if arg is None:
             raise NotImplementedError("arg=None not supported")
 


### PR DESCRIPTION
temporary solution to simplify testing, we need a shuffle kwarg here