### PR TITLE
GroupBy.rolling - Integer window type

### DIFF
--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -1,6 +1,7 @@
 import functools
 import math
 import warnings
+from numbers import Integral
 
 import numpy as np
 from dask import is_dask_collection
@@ -1302,6 +1303,12 @@ class GroupBy:
 
     def rolling(self, window, min_periods=None, center=False, win_type=None, axis=0):
         from dask_expr._rolling import Rolling
+
+        if isinstance(window, Integral):
+            raise ValueError(
+                "Only time indexes are supported for rolling groupbys in dask dataframe. "
+                "``window`` must be a ``freq`` (e.g. '1H')."
+            )
 
         return Rolling(
             self.obj,

--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -1,7 +1,6 @@
 import functools
 import math
 import warnings
-from numbers import Integral
 
 import numpy as np
 from dask import is_dask_collection
@@ -1303,12 +1302,6 @@ class GroupBy:
 
     def rolling(self, window, min_periods=None, center=False, win_type=None, axis=0):
         from dask_expr._rolling import Rolling
-
-        if isinstance(window, Integral):
-            raise ValueError(
-                "Only time indexes are supported for rolling groupbys in dask dataframe. "
-                "``window`` must be a ``freq`` (e.g. '1H')."
-            )
 
         return Rolling(
             self.obj,

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -588,9 +588,6 @@ def test_groupby_rolling():
 
     ddf = from_pandas(df, npartitions=8)
 
-    with pytest.raises(ValueError, match="``window`` must be a ``freq``"):
-        ddf.groupby("group1").rolling(1).sum()
-
     expected = df.groupby("group1").rolling("1D").sum()
     actual = ddf.groupby("group1").rolling("1D").sum()
 
@@ -600,6 +597,27 @@ def test_groupby_rolling():
     actual = ddf.groupby("group1").column1.rolling("1D").mean()
 
     assert_eq(expected, actual, check_divisions=False)
+
+    # Integer window w/ DateTimeIndex
+    expected = df.groupby("group1").rolling(1).sum()
+    actual = ddf.groupby("group1").rolling(1).sum()
+    assert_eq(expected, actual, check_divisions=False)
+
+    # Integer window w/o DateTimeIndex
+    expected = df.reset_index(drop=True).groupby("group1").rolling(1).sum()
+    actual = (
+        from_pandas(df.reset_index(drop=True), npartitions=10)
+        .groupby("group1")
+        .rolling(1)
+        .sum()
+    )
+    assert_eq(expected, actual, check_divisions=False)
+
+    # Integer window fails w/ datetime in groupby
+    with pytest.raises(lib.errors.DataError, match="Cannot aggregate non-numeric type"):
+        df.reset_index().groupby("group1").rolling(1).sum()
+    with pytest.raises(lib.errors.DataError, match="Cannot aggregate non-numeric type"):
+        from_pandas(df.reset_index(), npartitions=10).groupby("group1").rolling(1).sum()
 
 
 def test_rolling_groupby_projection():

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -588,6 +588,9 @@ def test_groupby_rolling():
 
     ddf = from_pandas(df, npartitions=8)
 
+    with pytest.raises(ValueError, match="``window`` must be a ``freq``"):
+        ddf.groupby("group1").rolling(1).sum()
+
     expected = df.groupby("group1").rolling("1D").sum()
     actual = ddf.groupby("group1").rolling("1D").sum()
 


### PR DESCRIPTION
Will close #493 

Two approaches here 

First (904646bd77b035bb37d30349005bc950268edca8) alters `GroupBy.rolling` to simply check window is an integer and raise the exact error dask/dask does currently.

Second (bdb61d9db6e0ddb1eeaa15c3e06a9597b346203a) allows it and only adds tests for the expected failures. Fine to use integer window if only numeric data in the dataframe, otherwise it raises the expected "Cannot aggregate non-numeric type".

If we want the second, I suppose we could follow up with a `numeric_only` as a convenience?