### PR TITLE
Avoid passing interleave_partitions through

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -1890,8 +1890,11 @@ def concat(
     join="outer",
     ignore_unknown_divisions=False,
     ignore_order=False,
+    interleave_partitions=False,
     **kwargs,
 ):
+    if interleave_partitions is True:
+        raise NotImplementedError("interleave_partitions=True isn't implemented yet")
     if not isinstance(dfs, list):
         raise TypeError("dfs must be a list of DataFrames/Series objects")
     if len(dfs) == 0:


### PR DESCRIPTION
Just a quick fixup before we actually implement this, but the keyword is passed to the pandas call at the moment, which is bad

ref #525