### PR TITLE
Add min_count to GroupBy.sum/prod methods

### DIFF
--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -1129,13 +1129,19 @@ class GroupBy:
     def count(self, **kwargs):
         return self._single_agg(Count, **kwargs)
 
-    def sum(self, numeric_only=False, **kwargs):
+    def sum(self, numeric_only=False, min_count=None, **kwargs):
         numeric_kwargs = self._numeric_only_kwargs(numeric_only)
-        return self._single_agg(Sum, **kwargs, **numeric_kwargs)
+        result = self._single_agg(Sum, **kwargs, **numeric_kwargs)
+        if min_count:
+            return result.where(self.count() >= min_count, other=np.nan)
+        return result
 
-    def prod(self, numeric_only=False, **kwargs):
+    def prod(self, numeric_only=False, min_count=None, **kwargs):
         numeric_kwargs = self._numeric_only_kwargs(numeric_only)
-        return self._single_agg(Prod, **kwargs, **numeric_kwargs)
+        result = self._single_agg(Prod, **kwargs, **numeric_kwargs)
+        if min_count:
+            return result.where(self.count() >= min_count, other=np.nan)
+        return result
 
     def mean(self, numeric_only=False, **kwargs):
         numeric_kwargs = self._numeric_only_kwargs(numeric_only)

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -736,3 +736,33 @@ def test_groupby_index_array(pdf):
         pdf.groupby(pdf.index.month).x.nunique(),
         check_names=False,
     )
+
+
+@pytest.mark.parametrize("min_count", [0, 1, 2, 3])
+@pytest.mark.parametrize("op", ("prod", "sum"))
+def test_with_min_count(min_count, op):
+    dfs = [
+        lib.DataFrame(
+            {
+                "group": ["A", "A", "B"],
+                "val1": [np.nan, 2, 3],
+                "val2": [np.nan, 5, 6],
+                "val3": [5, 4, 9],
+            }
+        ),
+        lib.DataFrame(
+            {
+                "group": ["A", "A", "B"],
+                "val1": [2, np.nan, np.nan],
+                "val2": [np.nan, 5, 6],
+                "val3": [5, 4, 9],
+            }
+        ),
+    ]
+    ddfs = [from_pandas(df, npartitions=4) for df in dfs]
+
+    for df, ddf in zip(dfs, ddfs):
+        assert_eq(
+            getattr(df.groupby("group"), op)(min_count=min_count),
+            getattr(ddf.groupby("group"), op)(min_count=min_count),
+        )


### PR DESCRIPTION
Will close #589 

From what I can see, `min_count` is only found on GroupBy.prod/sum methods in Dask, so only added it to those. 