### PR TITLE
Fix value_counts with normalize and split_out

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -1586,9 +1586,14 @@ class Series(FrameBase):
         split_every=None,
         split_out=1,
     ):
+        length = None
+        if (split_out > 1 or split_out is True) and normalize:
+            frame = self if not dropna else self.dropna()
+            length = Len(frame)
+
         return new_collection(
             ValueCounts(
-                self, sort, ascending, dropna, normalize, split_every, split_out
+                self, sort, ascending, dropna, normalize, split_every, split_out, length
             )
         )
 

--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -90,6 +90,10 @@ class Aggregate(Chunk):
 
     _parameters = ["frame", "kind", "aggregate", "aggregate_kwargs"]
 
+    @functools.cached_property
+    def aggregate_args(self):
+        return self.operands[len(self._parameters) :]
+
     @staticmethod
     def _call_with_list_arg(func, *args, **kwargs):
         return func(list(args), **kwargs)
@@ -100,7 +104,10 @@ class Aggregate(Chunk):
 
     @functools.cached_property
     def _args(self) -> list:
-        return [self.frame]
+        args = [self.frame]
+        if self.aggregate_args is not None:
+            args.extend(self.aggregate_args)
+        return args
 
     @functools.cached_property
     def _kwargs(self) -> dict:
@@ -125,6 +132,7 @@ class ShuffleReduce(Expr):
         "combine",
         "aggregate",
         "combine_kwargs",
+        "aggregate_args",
         "aggregate_kwargs",
         "split_by",
         "split_every",
@@ -234,6 +242,7 @@ class ShuffleReduce(Expr):
             self.kind,
             self.aggregate,
             self.aggregate_kwargs,
+            *self.aggregate_args,
         )
 
         # Repartition and return
@@ -374,6 +383,7 @@ class ApplyConcatApply(Expr):
     aggregate = None
     chunk_kwargs = {}
     combine_kwargs = {}
+    aggregate_args = []
     aggregate_kwargs = {}
     _chunk_cls = Chunk
 
@@ -466,6 +476,7 @@ class ApplyConcatApply(Expr):
             combine,
             aggregate,
             combine_kwargs,
+            self.aggregate_args,
             aggregate_kwargs,
             split_by=self.split_by,
             split_out=self.split_out,
@@ -1127,6 +1138,7 @@ class ValueCounts(ReductionConstantDim):
         "normalize": False,
         "split_every": None,
         "split_out": 1,
+        "total_length": None,
     }
 
     _parameters = [
@@ -1137,14 +1149,35 @@ class ValueCounts(ReductionConstantDim):
         "normalize",
         "split_every",
         "split_out",
+        "total_length",
     ]
     reduction_chunk = M.value_counts
     reduction_aggregate = methods.value_counts_aggregate
     reduction_combine = methods.value_counts_combine
 
+    @functools.cached_property
+    def _meta(self):
+        return self.frame._meta.value_counts(normalize=self.normalize)
+
+    @classmethod
+    def aggregate(cls, inputs, **kwargs):
+        func = cls.reduction_aggregate or cls.reduction_chunk
+        df = _concat(inputs[:-1])
+        return func(df, inputs[-1], **kwargs)
+
+    @property
+    def split_by(self):
+        return self.frame._meta.name
+
     @property
     def chunk_kwargs(self):
         return {"sort": self.sort, "ascending": self.ascending, "dropna": self.dropna}
+
+    @property
+    def aggregate_args(self):
+        if self.normalize and self.split_out != 1:
+            return [self.total_length]
+        return [None]
 
     @property
     def aggregate_kwargs(self):

--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -1162,8 +1162,10 @@ class ValueCounts(ReductionConstantDim):
     @classmethod
     def aggregate(cls, inputs, **kwargs):
         func = cls.reduction_aggregate or cls.reduction_chunk
-        df = _concat(inputs[:-1])
-        return func(df, inputs[-1], **kwargs)
+        if is_scalar(inputs[-1]):
+            return func(_concat(inputs[:-1]), inputs[-1], **kwargs)
+        else:
+            return func(_concat(inputs), **kwargs)
 
     @property
     def split_by(self):
@@ -1177,7 +1179,7 @@ class ValueCounts(ReductionConstantDim):
     def aggregate_args(self):
         if self.normalize and self.split_out != 1:
             return [self.total_length]
-        return [None]
+        return []
 
     @property
     def aggregate_kwargs(self):

--- a/dask_expr/_util.py
+++ b/dask_expr/_util.py
@@ -7,6 +7,7 @@ from types import LambdaType
 from typing import Any, Literal, TypeVar, cast
 
 import dask
+import numpy as np
 import pandas as pd
 from dask import config
 from dask.base import normalize_token, tokenize
@@ -79,8 +80,10 @@ def _convert_to_list(column) -> list | None:
 
 def is_scalar(x):
     # np.isscalar does not work for some pandas scalars, for example pd.NA
-    if isinstance(x, Sequence) and not isinstance(x, str) or hasattr(x, "dtype"):
+    if isinstance(x, Sequence) and not isinstance(x, str):
         return False
+    elif hasattr(x, "dtype"):
+        return isinstance(x, np.ScalarType)
     if isinstance(x, dict):
         return False
     if isinstance(x, (str, int)) or x is None:

--- a/dask_expr/_util.py
+++ b/dask_expr/_util.py
@@ -18,7 +18,7 @@ K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")
 
 DASK_VERSION = Version(dask.__version__)
-DASK_GT_20231000 = DASK_VERSION > Version("2023.10.0")
+DASK_GT_20231201 = DASK_VERSION > Version("2023.12.1")
 
 
 def _calc_maybe_new_divisions(df, periods, freq):

--- a/dask_expr/tests/test_reductions.py
+++ b/dask_expr/tests/test_reductions.py
@@ -136,3 +136,9 @@ def test_unique_base(df, pdf):
         df.index.unique().compute().sort_values().values,
         lib.Index(pdf.index.unique()).values,
     )
+
+
+def test_value_counts_split_out_normalize(df, pdf):
+    result = df.x.value_counts(split_out=2, normalize=True)
+    expected = pdf.x.value_counts(normalize=True)
+    assert_eq(result, expected)

--- a/dask_expr/tests/test_reductions.py
+++ b/dask_expr/tests/test_reductions.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from dask_expr import from_pandas
+from dask_expr._util import DASK_GT_20231201
 from dask_expr.tests._util import _backend_library, assert_eq
 
 # Set DataFrame backend for this module
@@ -138,6 +139,7 @@ def test_unique_base(df, pdf):
     )
 
 
+@pytest.mark.skipif(not DASK_GT_20231201, reason="needed updates in dask")
 def test_value_counts_split_out_normalize(df, pdf):
     result = df.x.value_counts(split_out=2, normalize=True)
     expected = pdf.x.value_counts(normalize=True)


### PR DESCRIPTION
ref #525

dask/dask currently calculates the length eagerly, this defers the length computation properly, but is kind of ugly, not sure