### PR TITLE
Align defaults for `split_out` for all `aggregate` methods

### DIFF
--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -279,7 +279,7 @@ class GroupbyAggregation(GroupByApplyConcatApply, GroupByBase):
         "observed": None,
         "dropna": None,
         "split_every": 8,
-        "split_out": None,
+        "split_out": 1,
         "sort": None,
         "_slice": None,
     }
@@ -1299,7 +1299,7 @@ class GroupBy:
             result = result[result.columns[0]]
         return result
 
-    def aggregate(self, arg=None, split_every=8, split_out=None, **kwargs):
+    def aggregate(self, arg=None, split_every=8, split_out=1, **kwargs):
         if arg is None:
             raise NotImplementedError("arg=None not supported")
 


### PR DESCRIPTION
Align defaults for `split_out` for all `aggregate` methods and makes sure it matches with `dask/dask`.