### PR TITLE
Avoid using ``map_partitions`` within internal dask-expr logic

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -54,10 +54,12 @@ from dask_expr._describe import DescribeNonNumeric, DescribeNumeric
 from dask_expr._expr import (
     BFill,
     Diff,
+    DiffColumns,
     Eval,
     FFill,
     Query,
     Shift,
+    ShiftColumns,
     ToDatetime,
     ToNumeric,
     ToTimedelta,
@@ -778,29 +780,16 @@ class FrameBase(DaskMethodsMixin):
 
         axis = _validate_axis(axis)
         if axis == 0:
-            return new_collection(Shift(self, periods, freq))
-
-        return self.map_partitions(
-            func=Shift.func,
-            enforce_metadata=False,
-            transform_divisions=False,
-            periods=periods,
-            axis=axis,
-            freq=freq,
-        )
+            return new_collection(Shift(self.expr, periods, freq))
+        else:
+            return new_collection(ShiftColumns(self.expr, periods, freq))
 
     def diff(self, periods=1, axis=0):
         axis = _validate_axis(axis)
         if axis == 0:
-            return new_collection(Diff(self, periods))
-        return self.map_partitions(
-            func=Diff.func,
-            enforce_metadata=False,
-            transform_divisions=False,
-            clear_divisions=False,
-            periods=periods,
-            axis=axis,
-        )
+            return new_collection(Diff(self.expr, periods))
+        else:
+            return new_collection(DiffColumns(self.expr, periods))
 
     def rename_axis(
         self, mapper=no_default, index=no_default, columns=no_default, axis=0
@@ -2485,4 +2474,4 @@ def isna(arg):
     if isinstance(arg, FrameBase):
         return arg.isna()
     else:
-        return map_partitions(pd.isna, from_pandas(arg))
+        return from_pandas(arg).isna()

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -54,12 +54,10 @@ from dask_expr._describe import DescribeNonNumeric, DescribeNumeric
 from dask_expr._expr import (
     BFill,
     Diff,
-    DiffColumns,
     Eval,
     FFill,
     Query,
     Shift,
-    ShiftColumns,
     ToDatetime,
     ToNumeric,
     ToTimedelta,
@@ -780,16 +778,29 @@ class FrameBase(DaskMethodsMixin):
 
         axis = _validate_axis(axis)
         if axis == 0:
-            return new_collection(Shift(self.expr, periods, freq))
-        else:
-            return new_collection(ShiftColumns(self.expr, periods, freq))
+            return new_collection(Shift(self, periods, freq))
+
+        return self.map_partitions(
+            func=Shift.func,
+            enforce_metadata=False,
+            transform_divisions=False,
+            periods=periods,
+            axis=axis,
+            freq=freq,
+        )
 
     def diff(self, periods=1, axis=0):
         axis = _validate_axis(axis)
         if axis == 0:
-            return new_collection(Diff(self.expr, periods))
-        else:
-            return new_collection(DiffColumns(self.expr, periods))
+            return new_collection(Diff(self, periods))
+        return self.map_partitions(
+            func=Diff.func,
+            enforce_metadata=False,
+            transform_divisions=False,
+            clear_divisions=False,
+            periods=periods,
+            axis=axis,
+        )
 
     def rename_axis(
         self, mapper=no_default, index=no_default, columns=no_default, axis=0

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2327,6 +2327,34 @@ class ShiftIndex(Blockwise):
         return {"freq": self.freq} if self.freq is not None else {}
 
 
+class ShiftColumns(Blockwise):
+    _parameters = ["frame", "periods", "freq"]
+    _defaults = {"periods": 1, "freq": None}
+    operation = M.shift
+
+    @functools.cached_property
+    def _args(self) -> list:
+        return [self.frame]
+
+    @functools.cached_property
+    def _kwargs(self) -> dict:
+        return {"periods": self.periods, "freq": self.freq, "axis": 1}
+
+
+class DiffColumns(Blockwise):
+    _parameters = ["frame", "periods"]
+    _defaults = {"periods": 1}
+    operation = M.diff
+
+    @functools.cached_property
+    def _args(self) -> list:
+        return [self.frame]
+
+    @functools.cached_property
+    def _kwargs(self) -> dict:
+        return {"periods": self.periods, "axis": 1}
+
+
 class Fused(Blockwise):
     """Fused ``Blockwise`` expression
 

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2327,34 +2327,6 @@ class ShiftIndex(Blockwise):
         return {"freq": self.freq} if self.freq is not None else {}
 
 
-class ShiftColumns(Blockwise):
-    _parameters = ["frame", "periods", "freq"]
-    _defaults = {"periods": 1, "freq": None}
-    operation = M.shift
-
-    @functools.cached_property
-    def _args(self) -> list:
-        return [self.frame]
-
-    @functools.cached_property
-    def _kwargs(self) -> dict:
-        return {"periods": self.periods, "freq": self.freq, "axis": 1}
-
-
-class DiffColumns(Blockwise):
-    _parameters = ["frame", "periods"]
-    _defaults = {"periods": 1}
-    operation = M.diff
-
-    @functools.cached_property
-    def _args(self) -> list:
-        return [self.frame]
-
-    @functools.cached_property
-    def _kwargs(self) -> dict:
-        return {"periods": self.periods, "axis": 1}
-
-
 class Fused(Blockwise):
     """Fused ``Blockwise`` expression
 


### PR DESCRIPTION
We should avoid using `map_partitions` for `isna`. It blocks column projection and doesn't work for cudf.