### PR TITLE
Add io connectors through rountripping with dask/dask

### DIFF
--- a/dask_expr/__init__.py
+++ b/dask_expr/__init__.py
@@ -1,7 +1,13 @@
 from dask_expr import _version, datasets
 from dask_expr._collection import *
 from dask_expr.io._delayed import from_delayed
+from dask_expr.io.bag import to_bag
+from dask_expr.io.csv import to_csv
+from dask_expr.io.hdf import read_hdf, to_hdf
 from dask_expr.io.json import read_json, to_json
+from dask_expr.io.orc import read_orc, to_orc
 from dask_expr.io.parquet import to_parquet
+from dask_expr.io.records import to_records
+from dask_expr.io.sql import read_sql, read_sql_query, read_sql_table, to_sql
 
 __version__ = _version.get_versions()["version"]

--- a/dask_expr/__init__.py
+++ b/dask_expr/__init__.py
@@ -1,6 +1,7 @@
 from dask_expr import _version, datasets
 from dask_expr._collection import *
 from dask_expr.io._delayed import from_delayed
+from dask_expr.io.json import read_json, to_json
 from dask_expr.io.parquet import to_parquet
 
 __version__ = _version.get_versions()["version"]

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -903,9 +903,10 @@ class FrameBase(DaskMethodsMixin):
         if lengths is True:
             lengths = tuple(self.map_partitions(len).compute())
 
-        records = to_records(self)
+        frame = self.to_dask_dataframe()
+        records = to_records(frame)
 
-        chunks = self._validate_chunks(records, lengths)
+        chunks = frame._validate_chunks(records, lengths)
         records._chunks = (chunks[0],)
 
         return records

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -852,6 +852,76 @@ class FrameBase(DaskMethodsMixin):
 
         return to_json(self, filename, *args, **kwargs)
 
+    def to_sql(
+        self,
+        name: str,
+        uri: str,
+        schema=None,
+        if_exists: str = "fail",
+        index: bool = True,
+        index_label=None,
+        chunksize=None,
+        dtype=None,
+        method=None,
+        compute=True,
+        parallel=False,
+        engine_kwargs=None,
+    ):
+        from dask_expr.io.sql import to_sql
+
+        return to_sql(
+            self,
+            name,
+            uri,
+            schema=schema,
+            if_exists=if_exists,
+            index=index,
+            index_label=index_label,
+            chunksize=chunksize,
+            dtype=dtype,
+            method=method,
+            compute=compute,
+            parallel=parallel,
+            engine_kwargs=engine_kwargs,
+        )
+
+    def to_orc(self, path, *args, **kwargs):
+        """See dd.to_orc docstring for more information"""
+        from dask_expr.io.orc import to_orc
+
+        return to_orc(self, path, *args, **kwargs)
+
+    def to_csv(self, filename, **kwargs):
+        """See dd.to_csv docstring for more information"""
+        from dask_expr.io.csv import to_csv
+
+        return to_csv(self, filename, **kwargs)
+
+    def to_records(self, index=False, lengths=None):
+        from dask_expr.io.records import to_records
+
+        if lengths is True:
+            lengths = tuple(self.map_partitions(len).compute())
+
+        records = to_records(self)
+
+        chunks = self._validate_chunks(records, lengths)
+        records._chunks = (chunks[0],)
+
+        return records
+
+    def to_bag(self, index=False, format="tuple"):
+        """Create a Dask Bag from a Series"""
+        from dask_expr.io.bag import to_bag
+
+        return to_bag(self, index, format=format)
+
+    def to_hdf(self, path_or_buf, key, mode="a", append=False, **kwargs):
+        """See dd.to_hdf docstring for more information"""
+        from dask_expr.io.hdf import to_hdf
+
+        return to_hdf(self, path_or_buf, key, mode, append, **kwargs)
+
 
 # Add operator attributes
 for op in [
@@ -2112,6 +2182,9 @@ def read_csv(path, *args, usecols=None, **kwargs):
     if not isinstance(path, str):
         path = stringify_path(path)
     return new_collection(ReadCSV(path, *args, columns=usecols, **kwargs))
+
+
+read_table = read_csv
 
 
 def read_parquet(

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -846,6 +846,12 @@ class FrameBase(DaskMethodsMixin):
     ):
         return from_dict(data, npartitions, orient, dtype=dtype, columns=columns)
 
+    def to_json(self, filename, *args, **kwargs):
+        """See dd.to_json docstring for more information"""
+        from dask.dataframe.io import to_json
+
+        return to_json(self, filename, *args, **kwargs)
+
 
 # Add operator attributes
 for op in [

--- a/dask_expr/io/bag.py
+++ b/dask_expr/io/bag.py
@@ -1,0 +1,4 @@
+def to_bag(df, index=False, format="tuple"):
+    from dask.dataframe.io import to_bag as _to_bag
+
+    return _to_bag(df.to_dask_dataframe(), index=index, format=format)

--- a/dask_expr/io/csv.py
+++ b/dask_expr/io/csv.py
@@ -64,3 +64,37 @@ class ReadCSV(PartitionsFiltered, BlockwiseIO):
         if self._series:
             return (operator.getitem, self._tasks[index], self.columns[0])
         return self._tasks[index]
+
+
+def to_csv(
+    df,
+    filename,
+    single_file=False,
+    encoding="utf-8",
+    mode="wt",
+    name_function=None,
+    compression=None,
+    compute=True,
+    scheduler=None,
+    storage_options=None,
+    header_first_partition_only=None,
+    compute_kwargs=None,
+    **kwargs,
+):
+    from dask.dataframe.io.csv import to_csv as _to_csv
+
+    return _to_csv(
+        df.to_dask_dataframe(),
+        filename,
+        single_file=single_file,
+        encoding=encoding,
+        mode=mode,
+        name_function=name_function,
+        compression=compression,
+        compute=compute,
+        scheduler=scheduler,
+        storage_options=storage_options,
+        header_first_partition_only=header_first_partition_only,
+        compute_kwargs=compute_kwargs,
+        **kwargs,
+    )

--- a/dask_expr/io/hdf.py
+++ b/dask_expr/io/hdf.py
@@ -1,0 +1,58 @@
+from dask_expr import from_dask_dataframe
+
+
+def read_hdf(
+    pattern,
+    key,
+    start=0,
+    stop=None,
+    columns=None,
+    chunksize=1000000,
+    sorted_index=False,
+    lock=True,
+    mode="r",
+):
+    from dask.dataframe.io import read_hdf as _read_hdf
+
+    df = _read_hdf(
+        pattern,
+        key,
+        start=start,
+        stop=stop,
+        columns=columns,
+        chunksize=chunksize,
+        sorted_index=sorted_index,
+        lock=lock,
+        mode=mode,
+    )
+    return from_dask_dataframe(df)
+
+
+def to_hdf(
+    df,
+    path,
+    key,
+    mode="a",
+    append=False,
+    scheduler=None,
+    name_function=None,
+    compute=True,
+    lock=None,
+    dask_kwargs=None,
+    **kwargs,
+):
+    from dask.dataframe.io import to_hdf as _to_hdf
+
+    return _to_hdf(
+        df.to_dask_dataframe(),
+        path,
+        key,
+        mode=mode,
+        append=append,
+        scheduler=scheduler,
+        name_function=name_function,
+        compute=compute,
+        lock=lock,
+        dask_kwargs=dask_kwargs,
+        **kwargs,
+    )

--- a/dask_expr/io/json.py
+++ b/dask_expr/io/json.py
@@ -1,0 +1,72 @@
+import pandas as pd
+
+from dask_expr import from_dask_dataframe
+
+
+def read_json(
+    url_path,
+    orient="records",
+    lines=None,
+    storage_options=None,
+    blocksize=None,
+    sample=2**20,
+    encoding="utf-8",
+    errors="strict",
+    compression="infer",
+    meta=None,
+    engine=pd.read_json,
+    include_path_column=False,
+    path_converter=None,
+    **kwargs,
+):
+    from dask.dataframe.io.json import read_json
+
+    df = read_json(
+        url_path,
+        orient=orient,
+        lines=lines,
+        storage_options=storage_options,
+        blocksize=blocksize,
+        sample=sample,
+        encoding=encoding,
+        errors=errors,
+        compression=compression,
+        meta=meta,
+        engine=engine,
+        include_path_column=include_path_column,
+        path_converter=path_converter,
+        **kwargs,
+    )
+    return from_dask_dataframe(df)
+
+
+def to_json(
+    df,
+    url_path,
+    orient="records",
+    lines=None,
+    storage_options=None,
+    compute=True,
+    encoding="utf-8",
+    errors="strict",
+    compression=None,
+    compute_kwargs=None,
+    name_function=None,
+    **kwargs,
+):
+    from dask.dataframe.io.json import to_json
+
+    return to_json(
+        df.to_dask_dataframe(),
+        url_path,
+        orient=orient,
+        lines=lines,
+        storage_options=storage_options,
+        compute=compute,
+        encoding=encoding,
+        errors=errors,
+        compression=compression,
+        compute_kwargs=compute_kwargs,
+        name_function=name_function,
+        **kwargs,
+    )

--- a/dask_expr/io/orc.py
+++ b/dask_expr/io/orc.py
@@ -1,0 +1,46 @@
+from dask_expr import from_dask_dataframe
+
+
+def read_orc(
+    path,
+    engine="pyarrow",
+    columns=None,
+    index=None,
+    split_stripes=1,
+    aggregate_files=None,
+    storage_options=None,
+):
+    from dask.dataframe.io import read_orc as _read_orc
+
+    df = _read_orc(
+        path,
+        engine=engine,
+        columns=columns,
+        index=index,
+        split_stripes=split_stripes,
+        aggregate_files=aggregate_files,
+        storage_options=storage_options,
+    )
+    return from_dask_dataframe(df)
+
+
+def to_orc(
+    df,
+    path,
+    engine="pyarrow",
+    write_index=True,
+    storage_options=None,
+    compute=True,
+    compute_kwargs=None,
+):
+    from dask.dataframe.io import to_orc as _to_orc
+
+    return _to_orc(
+        df.to_dask_dataframe(),
+        path,
+        engine=engine,
+        write_index=write_index,
+        storage_options=storage_options,
+        compute=compute,
+        compute_kwargs=compute_kwargs,
+    )

--- a/dask_expr/io/records.py
+++ b/dask_expr/io/records.py
@@ -2,4 +2,4 @@ from dask.utils import M
 
 
 def to_records(df):
-    return df.to_dask_dataframe().map_partitions(M.to_records)
+    return df.map_partitions(M.to_records)

--- a/dask_expr/io/records.py
+++ b/dask_expr/io/records.py
@@ -1,0 +1,5 @@
+from dask.utils import M
+
+
+def to_records(df):
+    return df.to_dask_dataframe().map_partitions(M.to_records)

--- a/dask_expr/io/sql.py
+++ b/dask_expr/io/sql.py
@@ -1,0 +1,108 @@
+from dask_expr import from_dask_dataframe
+
+
+def read_sql(sql, con, index_col, **kwargs):
+    from dask.dataframe.io.sql import read_sql
+
+    df = read_sql(sql, con, index_col, **kwargs)
+    return from_dask_dataframe(df)
+
+
+def read_sql_table(
+    table_name,
+    con,
+    index_col,
+    divisions=None,
+    npartitions=None,
+    limits=None,
+    columns=None,
+    bytes_per_chunk="256 MiB",
+    head_rows=5,
+    schema=None,
+    meta=None,
+    engine_kwargs=None,
+    **kwargs,
+):
+    from dask.dataframe.io.sql import read_sql_table as _read_sql_table
+
+    df = _read_sql_table(
+        table_name,
+        con,
+        index_col,
+        divisions=divisions,
+        npartitions=npartitions,
+        limits=limits,
+        columns=columns,
+        bytes_per_chunk=bytes_per_chunk,
+        head_rows=head_rows,
+        schema=schema,
+        meta=meta,
+        engine_kwargs=engine_kwargs,
+        **kwargs,
+    )
+    return from_dask_dataframe(df)
+
+
+def read_sql_query(
+    sql,
+    con,
+    index_col,
+    divisions=None,
+    npartitions=None,
+    limits=None,
+    bytes_per_chunk="256 MiB",
+    head_rows=5,
+    meta=None,
+    engine_kwargs=None,
+    **kwargs,
+):
+    from dask.dataframe.io.sql import read_sql_query as _read_sql_query
+
+    df = _read_sql_query(
+        sql,
+        con,
+        index_col,
+        divisions=divisions,
+        npartitions=npartitions,
+        limits=limits,
+        bytes_per_chunk=bytes_per_chunk,
+        head_rows=head_rows,
+        meta=meta,
+        engine_kwargs=engine_kwargs,
+        **kwargs,
+    )
+    return from_dask_dataframe(df)
+
+
+def to_sql(
+    df,
+    name: str,
+    uri: str,
+    schema=None,
+    if_exists: str = "fail",
+    index: bool = True,
+    index_label=None,
+    chunksize=None,
+    dtype=None,
+    method=None,
+    compute=True,
+    parallel=False,
+    engine_kwargs=None,
+):
+    from dask.dataframe.io.sql import to_sql as _to_sql
+
+    return _to_sql(
+        df.to_dask_dataframe(),
+        name=name,
+        uri=uri,
+        schema=schema,
+        if_exists=if_exists,
+        index=index,
+        index_label=index_label,
+        chunksize=chunksize,
+        dtype=dtype,
+        method=method,
+        compute=compute,
+        parallel=parallel,
+        engine_kwargs=engine_kwargs,
+    )


### PR DESCRIPTION
cc @mrocklin 

This is probably the area where we can save time without losing much in the sense of performance and UX for users. We can switch them out one after another after we are happy with the other parts of the API, compromising here makes the most sense imo. Wdyt?