### PR TITLE
Add clear divisions

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -240,6 +240,9 @@ class FrameBase(DaskMethodsMixin):
             self._expr._meta.columns = columns
         self._expr = expr.ColumnsSetter(self, columns)
 
+    def clear_divisions(self):
+        return new_collection(expr.ClearDivisions(self))
+
     def __len__(self):
         return new_collection(Len(self)).compute()
 

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1477,6 +1477,18 @@ class Index(Elemwise):
         )
 
 
+def _return_input(df):
+    return df
+
+
+class ClearDivisions(Elemwise):
+    _parameters = ["frame"]
+    operation = staticmethod(_return_input)
+
+    def _divisions(self):
+        return (None,) * (self.frame.npartitions + 1)
+
+
 class Lengths(Expr):
     """Returns a tuple of partition lengths"""
 

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -716,6 +716,12 @@ def test_isna(pdf):
     assert_eq(isna(pdf.x), lib.isna(pdf.x))
 
 
+def test_clear_divisions(df):
+    result = df.clear_divisions()
+    assert not result.known_divisions
+    assert_eq(df, result, check_divisions=False)
+
+
 def test_abs_errors():
     df = lib.DataFrame(
         {


### PR DESCRIPTION
I don't particularly like this but I really don't want to mess with the divisions of an existing expression, so rather create an ID expression that sets the divisions to None,

We might want to consider deprecating this in the future, but not having it makes testing hard.

ref #525