### PR TITLE
Enable the "disk" shuffle method for cudf

### DIFF
--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -477,13 +477,16 @@ class DiskShuffle(SimpleShuffle):
             p.append(d, fsync=True)
 
     def _layer(self):
+        from dask.dataframe.dispatch import partd_encode_dispatch
+
         column = self.partitioning_index
         df = self.frame
 
         always_new_token = uuid.uuid1().hex
 
         p = ("zpartd-" + always_new_token,)
-        dsk1 = {p: (maybe_buffered_partd(),)}
+        encode_cls = partd_encode_dispatch(df._meta)
+        dsk1 = {p: (maybe_buffered_partd(encode_cls=encode_cls),)}
 
         # Partition data on disk
         name = "shuffle-partition-" + always_new_token
@@ -1118,7 +1121,8 @@ class _SetIndexPost(Blockwise):
 
     @staticmethod
     def operation(df, index_name, drop, set_name, column_dtype):
-        df = df.set_index(set_name, drop=drop).rename_axis(index=index_name)
+        df = df.set_index(set_name, drop=drop)
+        df.index.name = index_name
         df.columns = df.columns.astype(column_dtype)
         return df
 

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -562,7 +562,6 @@ def test_shuffle(df, pdf):
     assert_eq(result, pdf)
 
 
-@xfail_gpu("cudf groupby bug")
 def test_empty_partitions():
     # See https://github.com/dask/dask/issues/2408
     df = lib.DataFrame({"a": list(range(10))})

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -126,7 +126,7 @@ def test_task_shuffle_index(npartitions, max_branch, pdf):
     # If any values of "x" can be found in multiple
     # partitions, this will fail
     df3 = df2.index.map_partitions(lambda x: x.drop_duplicates())
-    assert sorted(df3.compute().index) == list(range(20))
+    assert sorted(df3.compute().values) == list(range(20))
 
 
 def test_shuffle_column_projection(df):
@@ -562,6 +562,7 @@ def test_shuffle(df, pdf):
     assert_eq(result, pdf)
 
 
+@xfail_gpu("cudf groupby bug")
 def test_empty_partitions():
     # See https://github.com/dask/dask/issues/2408
     df = lib.DataFrame({"a": list(range(10))})


### PR DESCRIPTION
Enables `shuffle_method="disk"` for cudf, and modifies several tests to work with both pandas and cudf.