### PR TITLE
Add extra check in _normalize_lambda for lambda function

### DIFF
--- a/dask_expr/_util.py
+++ b/dask_expr/_util.py
@@ -10,7 +10,7 @@ import dask
 import numpy as np
 import pandas as pd
 from dask import config
-from dask.base import normalize_token, tokenize
+from dask.base import normalize_object, normalize_token, tokenize
 from dask.dataframe._compat import is_string_dtype
 from dask.utils import get_default_shuffle_method
 from packaging.version import Version
@@ -102,7 +102,14 @@ def is_valid_nth_dtype(dtype):
 
 @normalize_token.register(LambdaType)
 def _normalize_lambda(func):
-    return str(func)
+    # free functions also are instances of LambdaType
+    # to be more sure, check the name
+    # and if cloudpickle can deterministically pickle it:
+    # ref: https://github.com/cloudpipe/cloudpickle/issues/385
+    result = str(func)
+    if func.__name__ == "<lambda>" or "<locals>" in result:
+        return result
+    return normalize_object(func)
 
 
 def _tokenize_deterministic(*args, **kwargs) -> str:

--- a/dask_expr/_util.py
+++ b/dask_expr/_util.py
@@ -102,13 +102,13 @@ def is_valid_nth_dtype(dtype):
 
 @normalize_token.register(LambdaType)
 def _normalize_lambda(func):
-    # free functions also are instances of LambdaType
-    # to be more sure, check the name
+    # Free functions also are instances of LambdaType.
+    # To be more sure, check the name
     # and if cloudpickle can deterministically pickle it:
     # ref: https://github.com/cloudpipe/cloudpickle/issues/385
-    result = str(func)
-    if func.__name__ == "<lambda>" or "<locals>" in result:
-        return result
+    func_str = str(func)
+    if func.__name__ == "<lambda>" or "<locals>" in func_str:
+        return func_str
     return normalize_object(func)
 
 


### PR DESCRIPTION
Will close https://github.com/dask/dask/issues/10760

TL/DR; dask-expr needs an extra check for a lambda function in `_normalize_lambda` since free functions are also instances of `types.LambdaType` (it's actually an [alias to `types.FunctionType`](https://docs.python.org/2/library/types.html#types.FunctionType)...because, why not?). And failing on Python 3.12 because that's the only one that also [includes a `dask-expr` dependency.](https://github.com/dask/dask/blob/63b6bb84015975c8466e80d1d498a293835ae936/continuous_integration/environment-3.12.yaml#L80)

---

git bisect'd to [#10676](https://github.com/dask/dask/pull/10676) (the last tests in that PR unsurprisingly also show the failing 3.12 test)

Running the failing test by itself (`test_use_cloudpickle_to_tokenize_functions_in__main__`) will work fine, but running the module (`python -m pytest -k test_base`) will bring the issue out. Then commenting out the two tests added in that PR will also allow everything to pass. 

Specifically, running by itself returns the expected bytes but running the module the `normalize_token` will instead return a string, like `'<function inc at 0x7f5e97dad9e0>'`, giving the error we saw in the failing test.
> TypeError: 'in <string>' requires string as left operand, not bytes

This was because dask-expr's `_utils._normalize_lambda` registered on `types.LambdaType`. Adding an extra check for the `'lambda'` function name as well as `<locals>` to avoid https://github.com/cloudpipe/cloudpickle/issues/385 resolves the issue. Just so happens the tests added in the referenced PR managed to import dask-expr and thus added `_normalize_lambda` to the mix.