### PR TITLE
Rename lib to pd

### DIFF
--- a/dask_expr/io/tests/test_delayed.py
+++ b/dask_expr/io/tests/test_delayed.py
@@ -4,11 +4,11 @@ from dask import delayed
 from dask_expr import from_delayed
 from dask_expr.tests._util import _backend_library, assert_eq
 
-lib = _backend_library()
+pd = _backend_library()
 
 
 def test_from_delayed():
-    pdf = lib.DataFrame(
+    pdf = pd.DataFrame(
         data=np.random.normal(size=(10, 4)), columns=["a", "b", "c", "d"]
     )
     parts = [pdf.iloc[:1], pdf.iloc[1:3], pdf.iloc[3:6], pdf.iloc[6:10]]

--- a/dask_expr/io/tests/test_distributed.py
+++ b/dask_expr/io/tests/test_distributed.py
@@ -11,11 +11,11 @@ from distributed.utils_test import client as c  # noqa F401
 
 import dask_expr as dx
 
-lib = _backend_library()
+pd = _backend_library()
 
 
 def test_io_fusion_merge(tmpdir):
-    pdf = lib.DataFrame({c: range(100) for c in "abcdefghij"})
+    pdf = pd.DataFrame({c: range(100) for c in "abcdefghij"})
     with LocalCluster(processes=False, n_workers=2) as cluster:
         with Client(cluster) as client:  # noqa: F841
             dx.from_pandas(pdf, 10).to_parquet(tmpdir)
@@ -23,7 +23,7 @@ def test_io_fusion_merge(tmpdir):
                 dx.read_parquet(tmpdir).add_suffix("_x"), left_on="a", right_on="a_x"
             )[["a_x", "b_x", "b"]]
             out = df.compute()
-    lib.testing.assert_frame_equal(
+    pd.testing.assert_frame_equal(
         out.sort_values(by="a_x", ignore_index=True),
         pdf.merge(pdf.add_suffix("_x"), left_on="a", right_on="a_x")[
             ["a_x", "b_x", "b"]

--- a/dask_expr/tests/test_categorical.py
+++ b/dask_expr/tests/test_categorical.py
@@ -5,12 +5,12 @@ from dask_expr._categorical import GetCategories
 from dask_expr.tests._util import _backend_library, assert_eq
 
 # Set DataFrame backend for this module
-lib = _backend_library()
+pd = _backend_library()
 
 
 @pytest.fixture
 def pdf():
-    pdf = lib.DataFrame({"x": [1, 2, 3, 4, 1, 2], "y": "bcbbbc"})
+    pdf = pd.DataFrame({"x": [1, 2, 3, 4, 1, 2], "y": "bcbbbc"})
     return pdf
 
 
@@ -27,9 +27,9 @@ def test_set_categories(pdf):
     ser = df.x.cat.as_unknown()
     assert not ser.cat.known
     ser = ser.cat.as_known()
-    assert_eq(ser.cat.categories, lib.Index([1, 2, 3, 4]))
+    assert_eq(ser.cat.categories, pd.Index([1, 2, 3, 4]))
     ser = ser.cat.set_categories([1, 2, 3, 5, 4])
-    assert_eq(ser.cat.categories, lib.Index([1, 2, 3, 5, 4]))
+    assert_eq(ser.cat.categories, pd.Index([1, 2, 3, 5, 4]))
     assert not ser.cat.ordered
 
 
@@ -51,8 +51,8 @@ def test_get_categories_simplify_adds_projection(df):
 
 
 def test_categorical_set_index():
-    df = lib.DataFrame({"x": [1, 2, 3, 4], "y": ["a", "b", "b", "c"]})
-    df["y"] = lib.Categorical(df["y"], categories=["a", "b", "c"], ordered=True)
+    df = pd.DataFrame({"x": [1, 2, 3, 4], "y": ["a", "b", "b", "c"]})
+    df["y"] = pd.Categorical(df["y"], categories=["a", "b", "c"], ordered=True)
     a = from_pandas(df, npartitions=2)
 
     b = a.set_index("y", divisions=["a", "b", "c"], npartitions=a.npartitions)

--- a/dask_expr/tests/test_concat.py
+++ b/dask_expr/tests/test_concat.py
@@ -5,12 +5,12 @@ from dask_expr import DataFrame, FrameBase, Len, Series, concat, from_pandas
 from dask_expr.tests._util import _backend_library, assert_eq
 
 # Set DataFrame backend for this module
-lib = _backend_library()
+pd = _backend_library()
 
 
 @pytest.fixture
 def pdf():
-    pdf = lib.DataFrame({"x": range(100)})
+    pdf = pd.DataFrame({"x": range(100)})
     pdf["y"] = pdf.x * 10.0
     yield pdf
 
@@ -28,14 +28,14 @@ def test_concat_str(df):
 
 def test_concat(pdf, df):
     result = concat([df, df])
-    expected = lib.concat([pdf, pdf])
+    expected = pd.concat([pdf, pdf])
     assert_eq(result, expected)
     assert all(div is None for div in result.divisions)
 
 
 def test_concat_pdf(pdf, df):
     result = concat([df, pdf])
-    expected = lib.concat([pdf, pdf])
+    expected = pd.concat([pdf, pdf])
     assert_eq(result, expected)
     assert all(div is None for div in result.divisions)
 
@@ -44,7 +44,7 @@ def test_concat_divisions(pdf, df):
     pdf2 = pdf.set_index(np.arange(200, 300))
     df2 = from_pandas(pdf2, npartitions=10)
     result = concat([df, df2])
-    expected = lib.concat([pdf, pdf2])
+    expected = pd.concat([pdf, pdf2])
     assert_eq(result, expected)
     assert not any(div is None for div in result.divisions)
 
@@ -64,14 +64,14 @@ def test_concat_invalid():
 
 def test_concat_one_object(df, pdf):
     result = concat([df])
-    expected = lib.concat([pdf])
+    expected = pd.concat([pdf])
     assert_eq(result, expected)
     assert not any(div is None for div in result.divisions)
 
 
 def test_concat_one_no_columns(df, pdf):
     result = concat([df, df[[]]])
-    expected = lib.concat([pdf, pdf[[]]])
+    expected = pd.concat([pdf, pdf[[]]])
     assert_eq(result, expected)
 
 
@@ -84,7 +84,7 @@ def test_concat_simplify(pdf, df):
     expected = concat([df[["x"]], df2[["x", "z"]]]).simplify()[["z", "x"]]
     assert result._name == expected._name
 
-    assert_eq(q, lib.concat([pdf, pdf2])[["z", "x"]])
+    assert_eq(q, pd.concat([pdf, pdf2])[["z", "x"]])
 
 
 def test_concat_simplify_projection_not_added(pdf, df):
@@ -96,13 +96,13 @@ def test_concat_simplify_projection_not_added(pdf, df):
     expected = concat([df, df2[["x", "y"]]]).simplify()[["y", "x"]]
     assert result._name == expected._name
 
-    assert_eq(q, lib.concat([pdf, pdf2])[["y", "x"]])
+    assert_eq(q, pd.concat([pdf, pdf2])[["y", "x"]])
 
 
 def test_concat_axis_one_co_aligned(pdf, df):
     df2 = df.add_suffix("_2")
     pdf2 = pdf.add_suffix("_2")
-    assert_eq(concat([df, df2], axis=1), lib.concat([pdf, pdf2], axis=1))
+    assert_eq(concat([df, df2], axis=1), pd.concat([pdf, pdf2], axis=1))
 
 
 def test_concat_axis_one_all_divisions_unknown(pdf):
@@ -112,10 +112,10 @@ def test_concat_axis_one_all_divisions_unknown(pdf):
     pdf2 = pdf.add_suffix("_2")
     df2 = from_pandas(pdf2, npartitions=2, sort=False)
     with pytest.warns(UserWarning):
-        assert_eq(concat([df, df2], axis=1), lib.concat([pdf, pdf2], axis=1))
+        assert_eq(concat([df, df2], axis=1), pd.concat([pdf, pdf2], axis=1))
     assert_eq(
         concat([df, df2], axis=1, ignore_unknown_divisions=True),
-        lib.concat([pdf, pdf2], axis=1),
+        pd.concat([pdf, pdf2], axis=1),
     )
 
 
@@ -127,27 +127,23 @@ def test_concat_axis_one_drop_dfs_not_selected(pdf, df):
     result = concat([df, df2, df3], axis=1)[["x", "y", "x_2"]].simplify()
     expected = concat([df, df2[["x_2"]]], axis=1).simplify()
     assert result._name == expected._name
-    assert_eq(result, lib.concat([pdf, pdf2, pdf3], axis=1)[["x", "y", "x_2"]])
+    assert_eq(result, pd.concat([pdf, pdf2, pdf3], axis=1)[["x", "y", "x_2"]])
 
 
 def test_concat_ignore_order():
-    pdf1 = lib.DataFrame(
+    pdf1 = pd.DataFrame(
         {
-            "x": lib.Categorical(
+            "x": pd.Categorical(
                 ["a", "b", "c", "a"], categories=["a", "b", "c"], ordered=True
             )
         }
     )
     ddf1 = from_pandas(pdf1, 2)
-    pdf2 = lib.DataFrame(
-        {
-            "x": lib.Categorical(
-                ["c", "b", "a"], categories=["c", "b", "a"], ordered=True
-            )
-        }
+    pdf2 = pd.DataFrame(
+        {"x": pd.Categorical(["c", "b", "a"], categories=["c", "b", "a"], ordered=True)}
     )
     ddf2 = from_pandas(pdf2, 2)
-    expected = lib.concat([pdf1, pdf2])
+    expected = pd.concat([pdf1, pdf2])
     expected["x"] = expected["x"].astype("category")
     result = concat([ddf1, ddf2], ignore_order=True)
     assert_eq(result, expected)
@@ -156,7 +152,7 @@ def test_concat_ignore_order():
 def test_concat_index(df, pdf):
     df2 = from_pandas(pdf, npartitions=3)
     result = concat([df, df2])
-    expected = lib.concat([pdf, pdf])
+    expected = pd.concat([pdf, pdf])
     assert_eq(len(result), len(expected))
 
     query = Len(result.expr).optimize(fuse=False)
@@ -173,9 +169,9 @@ def test_concat_one_series(df):
 
 
 def test_concat_dataframe_empty():
-    df = lib.DataFrame({"a": [100, 200, 300]}, dtype="int64")
-    empty_df = lib.DataFrame([], dtype="int64")
-    df_concat = lib.concat([df, empty_df])
+    df = pd.DataFrame({"a": [100, 200, 300]}, dtype="int64")
+    empty_df = pd.DataFrame([], dtype="int64")
+    df_concat = pd.concat([df, empty_df])
 
     ddf = from_pandas(df, npartitions=1)
     empty_ddf = from_pandas(empty_df, npartitions=1)
@@ -184,15 +180,15 @@ def test_concat_dataframe_empty():
 
 
 def test_concat_after_merge():
-    pdf1 = lib.DataFrame(
+    pdf1 = pd.DataFrame(
         {"x": range(10), "y": [1, 2, 3, 4, 5] * 2, "z": ["cat", "dog"] * 5}
     )
-    pdf2 = lib.DataFrame(
+    pdf2 = pd.DataFrame(
         {"i": range(10), "j": [2, 3, 4, 5, 6] * 2, "k": ["bird", "dog"] * 5}
     )
     _pdf1 = pdf1[pdf1["z"] == "cat"].merge(pdf2, left_on="y", right_on="j")
     _pdf2 = pdf1[pdf1["z"] == "dog"].merge(pdf2, left_on="y", right_on="j")
-    ptotal = lib.concat([_pdf1, _pdf2])
+    ptotal = pd.concat([_pdf1, _pdf2])
 
     df1 = from_pandas(pdf1, npartitions=2)
     df2 = from_pandas(pdf2, npartitions=2)
@@ -204,13 +200,13 @@ def test_concat_after_merge():
 
 
 def test_concat4_interleave_partitions():
-    pdf1 = lib.DataFrame(
+    pdf1 = pd.DataFrame(
         np.random.randn(10, 5), columns=list("ABCDE"), index=list("abcdefghij")
     )
-    pdf2 = lib.DataFrame(
+    pdf2 = pd.DataFrame(
         np.random.randn(13, 5), columns=list("ABCDE"), index=list("fghijklmnopqr")
     )
-    pdf3 = lib.DataFrame(
+    pdf3 = pd.DataFrame(
         np.random.randn(13, 6), columns=list("CDEXYZ"), index=list("fghijklmnopqr")
     )
 
@@ -231,11 +227,11 @@ def test_concat4_interleave_partitions():
         pdcase = [c.compute() for c in case]
 
         assert_eq(
-            concat(case, interleave_partitions=True), lib.concat(pdcase, sort=False)
+            concat(case, interleave_partitions=True), pd.concat(pdcase, sort=False)
         )
         assert_eq(
             concat(case, join="inner", interleave_partitions=True),
-            lib.concat(pdcase, join="inner", sort=False),
+            pd.concat(pdcase, join="inner", sort=False),
         )
 
     with pytest.raises(ValueError, match="'join' must be 'inner' or 'outer'"):
@@ -243,19 +239,19 @@ def test_concat4_interleave_partitions():
 
 
 def test_concat5():
-    pdf1 = lib.DataFrame(
+    pdf1 = pd.DataFrame(
         np.random.randn(7, 5), columns=list("ABCDE"), index=list("abcdefg")
     )
-    pdf2 = lib.DataFrame(
+    pdf2 = pd.DataFrame(
         np.random.randn(7, 6), columns=list("FGHIJK"), index=list("abcdefg")
     )
-    pdf3 = lib.DataFrame(
+    pdf3 = pd.DataFrame(
         np.random.randn(7, 6), columns=list("FGHIJK"), index=list("cdefghi")
     )
-    pdf4 = lib.DataFrame(
+    pdf4 = pd.DataFrame(
         np.random.randn(7, 5), columns=list("FGHAB"), index=list("cdefghi")
     )
-    pdf5 = lib.DataFrame(
+    pdf5 = pd.DataFrame(
         np.random.randn(7, 5), columns=list("FGHAB"), index=list("fklmnop")
     )
 
@@ -290,19 +286,19 @@ def test_concat5():
 
         assert_eq(
             concat(case, interleave_partitions=True),
-            lib.concat(pdcase, sort=False),
+            pd.concat(pdcase, sort=False),
         )
 
         assert_eq(
             concat(case, join="inner", interleave_partitions=True),
-            lib.concat(pdcase, join="inner"),
+            pd.concat(pdcase, join="inner"),
         )
 
-        assert_eq(concat(case, axis=1), lib.concat(pdcase, axis=1))
+        assert_eq(concat(case, axis=1), pd.concat(pdcase, axis=1))
 
         assert_eq(
             concat(case, axis=1, join="inner"),
-            lib.concat(pdcase, axis=1, join="inner"),
+            pd.concat(pdcase, axis=1, join="inner"),
         )
 
     # Dask + pandas
@@ -320,18 +316,18 @@ def test_concat5():
     for case in cases:
         pdcase = [c.compute() if isinstance(c, FrameBase) else c for c in case]
 
-        assert_eq(concat(case, interleave_partitions=True), lib.concat(pdcase))
+        assert_eq(concat(case, interleave_partitions=True), pd.concat(pdcase))
 
         assert_eq(
             concat(case, join="inner", interleave_partitions=True),
-            lib.concat(pdcase, join="inner"),
+            pd.concat(pdcase, join="inner"),
         )
 
-        assert_eq(concat(case, axis=1), lib.concat(pdcase, axis=1))
+        assert_eq(concat(case, axis=1), pd.concat(pdcase, axis=1))
 
         assert_eq(
             concat(case, axis=1, join="inner"),
-            lib.concat(pdcase, axis=1, join="inner"),
+            pd.concat(pdcase, axis=1, join="inner"),
         )
 
 
@@ -342,4 +338,4 @@ def test_concat_series(pdf):
     df2 = df[["x", "y"]]
     expected = concat([df2.y, df2.x], axis=1)[["x", "y"]]
     assert q.optimize(fuse=False)._name == expected.optimize(fuse=False)._name
-    assert_eq(q, lib.concat([pdf.y, pdf.x, pdf.z], axis=1)[["x", "y"]])
+    assert_eq(q, pd.concat([pdf.y, pdf.x, pdf.z], axis=1)[["x", "y"]])

--- a/dask_expr/tests/test_datetime.py
+++ b/dask_expr/tests/test_datetime.py
@@ -3,12 +3,12 @@ import pytest
 from dask_expr._collection import from_pandas
 from dask_expr.tests._util import _backend_library, assert_eq
 
-lib = _backend_library()
+pd = _backend_library()
 
 
 @pytest.fixture()
 def ser():
-    return lib.Series(lib.date_range(start="2020-01-01", end="2020-03-03"))
+    return pd.Series(pd.date_range(start="2020-01-01", end="2020-03-03"))
 
 
 @pytest.fixture()
@@ -18,7 +18,7 @@ def dser(ser):
 
 @pytest.fixture()
 def ser_td():
-    return lib.Series(lib.timedelta_range(start="0s", end="1000s", freq="s"))
+    return pd.Series(pd.timedelta_range(start="0s", end="1000s", freq="s"))
 
 
 @pytest.fixture()
@@ -28,7 +28,7 @@ def dser_td(ser_td):
 
 @pytest.fixture()
 def ser_pr():
-    return lib.Series(lib.period_range(start="2020-01-01", end="2020-12-31", freq="D"))
+    return pd.Series(pd.period_range(start="2020-01-01", end="2020-12-31", freq="D"))
 
 
 @pytest.fixture()

--- a/dask_expr/tests/test_describe.py
+++ b/dask_expr/tests/test_describe.py
@@ -5,19 +5,19 @@ from dask_expr import from_pandas
 from dask_expr.tests._util import _backend_library, assert_eq
 
 # Set DataFrame backend for this module
-lib = _backend_library()
+pd = _backend_library()
 
 
 @pytest.fixture
 def pdf():
-    pdf = lib.DataFrame(
+    pdf = pd.DataFrame(
         {
             "x": [None, 0, 1, 2, 3, 4] * 2,
             "ts": [
-                lib.Timestamp("2017-05-09 00:00:00.006000"),
-                lib.Timestamp("2017-05-09 00:00:00.006000"),
-                lib.Timestamp("2017-05-09 07:56:23.858694"),
-                lib.Timestamp("2017-05-09 05:59:58.938999"),
+                pd.Timestamp("2017-05-09 00:00:00.006000"),
+                pd.Timestamp("2017-05-09 00:00:00.006000"),
+                pd.Timestamp("2017-05-09 07:56:23.858694"),
+                pd.Timestamp("2017-05-09 05:59:58.938999"),
                 None,
                 None,
             ]
@@ -44,10 +44,10 @@ def df(pdf):
 
 def _drop_mean(df, col=None):
     """TODO: In pandas 2.0, mean is implemented for datetimes, but Dask returns None."""
-    if isinstance(df, lib.DataFrame):
+    if isinstance(df, pd.DataFrame):
         df.at["mean", col] = np.nan
         df.dropna(how="all", inplace=True)
-    elif isinstance(df, lib.Series):
+    elif isinstance(df, pd.Series):
         df.drop(labels=["mean"], inplace=True, errors="ignore")
     else:
         raise NotImplementedError("Expected Series or DataFrame with mean")

--- a/dask_expr/tests/test_fusion.py
+++ b/dask_expr/tests/test_fusion.py
@@ -4,12 +4,12 @@ from dask_expr import from_pandas, optimize
 from dask_expr.tests._util import _backend_library, assert_eq
 
 # Set DataFrame backend for this module
-lib = _backend_library()
+pd = _backend_library()
 
 
 @pytest.fixture
 def pdf():
-    pdf = lib.DataFrame({"x": range(100)})
+    pdf = pd.DataFrame({"x": range(100)})
     pdf["y"] = pdf.x * 10.0
     yield pdf
 
@@ -47,8 +47,8 @@ def test_optimize_fusion_many():
     # Test that many `Blockwise`` operations,
     # originating from various IO operations,
     # can all be fused together
-    a = from_pandas(lib.DataFrame({"x": range(100), "y": range(100)}), 10)
-    b = from_pandas(lib.DataFrame({"a": range(100)}), 10)
+    a = from_pandas(pd.DataFrame({"x": range(100), "y": range(100)}), 10)
+    b = from_pandas(pd.DataFrame({"a": range(100)}), 10)
 
     # some generic elemwise operations
     aa = a[["x"]] + 1
@@ -106,9 +106,9 @@ def test_persist_with_fusion(df):
 
 
 def test_fuse_broadcast_deps():
-    pdf = lib.DataFrame({"a": [1, 2, 3]})
-    pdf2 = lib.DataFrame({"a": [2, 3, 4]})
-    pdf3 = lib.DataFrame({"a": [3, 4, 5]})
+    pdf = pd.DataFrame({"a": [1, 2, 3]})
+    pdf2 = pd.DataFrame({"a": [2, 3, 4]})
+    pdf3 = pd.DataFrame({"a": [3, 4, 5]})
     df = from_pandas(pdf, npartitions=1)
     df2 = from_pandas(pdf2, npartitions=1)
     df3 = from_pandas(pdf3, npartitions=2)

--- a/dask_expr/tests/test_indexing.py
+++ b/dask_expr/tests/test_indexing.py
@@ -3,12 +3,12 @@ import pytest
 from dask_expr import from_pandas
 from dask_expr.tests._util import _backend_library, assert_eq
 
-lib = _backend_library()
+pd = _backend_library()
 
 
 @pytest.fixture
 def pdf():
-    pdf = lib.DataFrame({"x": range(20)})
+    pdf = pd.DataFrame({"x": range(20)})
     pdf["y"] = pdf.x * 10.0
     yield pdf
 

--- a/dask_expr/tests/test_merge.py
+++ b/dask_expr/tests/test_merge.py
@@ -9,16 +9,16 @@ from dask_expr._shuffle import Shuffle
 from dask_expr.tests._util import _backend_library, assert_eq
 
 # Set DataFrame backend for this module
-lib = _backend_library()
+pd = _backend_library()
 
 
 @pytest.mark.parametrize("how", ["left", "right", "inner", "outer"])
 @pytest.mark.parametrize("shuffle_method", ["tasks", "disk"])
 def test_merge(how, shuffle_method):
     # Make simple left & right dfs
-    pdf1 = lib.DataFrame({"x": range(20), "y": range(20)})
+    pdf1 = pd.DataFrame({"x": range(20), "y": range(20)})
     df1 = from_pandas(pdf1, 4)
-    pdf2 = lib.DataFrame({"x": range(0, 20, 2), "z": range(10)})
+    pdf2 = pd.DataFrame({"x": range(0, 20, 2), "z": range(10)})
     df2 = from_pandas(pdf2, 2)
 
     # Partition-wise merge with map_partitions
@@ -40,9 +40,9 @@ def test_merge(how, shuffle_method):
 @pytest.mark.parametrize("shuffle_method", ["tasks", "disk"])
 def test_merge_indexed(how, pass_name, sort, shuffle_method):
     # Make simple left & right dfs
-    pdf1 = lib.DataFrame({"x": range(20), "y": range(20)}).set_index("x")
+    pdf1 = pd.DataFrame({"x": range(20), "y": range(20)}).set_index("x")
     df1 = from_pandas(pdf1, 4)
-    pdf2 = lib.DataFrame({"x": range(0, 20, 2), "z": range(10)}).set_index("x")
+    pdf2 = pd.DataFrame({"x": range(0, 20, 2), "z": range(10)}).set_index("x")
     df2 = from_pandas(pdf2, 2, sort=sort)
 
     if pass_name:
@@ -79,9 +79,9 @@ def test_merge_indexed(how, pass_name, sort, shuffle_method):
 @pytest.mark.parametrize("npartitions", [None, 22])
 def test_broadcast_merge(how, npartitions):
     # Make simple left & right dfs
-    pdf1 = lib.DataFrame({"x": range(40), "y": range(40)})
+    pdf1 = pd.DataFrame({"x": range(40), "y": range(40)})
     df1 = from_pandas(pdf1, 20)
-    pdf2 = lib.DataFrame({"x": range(0, 40, 2), "z": range(20)})
+    pdf2 = pd.DataFrame({"x": range(0, 40, 2), "z": range(20)})
     df2 = from_pandas(pdf2, 2)
 
     df3 = df1.merge(
@@ -103,9 +103,9 @@ def test_broadcast_merge(how, npartitions):
 
 def test_merge_column_projection():
     # Make simple left & right dfs
-    pdf1 = lib.DataFrame({"x": range(20), "y": range(20), "z": range(20)})
+    pdf1 = pd.DataFrame({"x": range(20), "y": range(20), "z": range(20)})
     df1 = from_pandas(pdf1, 4)
-    pdf2 = lib.DataFrame({"x": range(0, 20, 2), "z": range(10)})
+    pdf2 = pd.DataFrame({"x": range(0, 20, 2), "z": range(10)})
     df2 = from_pandas(pdf2, 2)
 
     # Partition-wise merge with map_partitions
@@ -118,9 +118,9 @@ def test_merge_column_projection():
 @pytest.mark.parametrize("shuffle_method", ["tasks", "disk"])
 def test_join(how, shuffle_method):
     # Make simple left & right dfs
-    pdf1 = lib.DataFrame({"x": range(20), "y": range(20)})
+    pdf1 = pd.DataFrame({"x": range(20), "y": range(20)})
     df1 = from_pandas(pdf1, 4)
-    pdf2 = lib.DataFrame({"z": range(10)}, index=lib.Index(range(10), name="a"))
+    pdf2 = pd.DataFrame({"z": range(10)}, index=pd.Index(range(10), name="a"))
     df2 = from_pandas(pdf2, 2)
 
     # Partition-wise merge with map_partitions
@@ -137,15 +137,15 @@ def test_join(how, shuffle_method):
 
 
 def test_join_recursive():
-    pdf = lib.DataFrame({"x": [1, 2, 3], "y": 1}, index=lib.Index([1, 2, 3], name="a"))
+    pdf = pd.DataFrame({"x": [1, 2, 3], "y": 1}, index=pd.Index([1, 2, 3], name="a"))
     df = from_pandas(pdf, npartitions=2)
 
-    pdf2 = lib.DataFrame(
-        {"a": [1, 2, 3, 4, 5, 6], "b": 1}, index=lib.Index([1, 2, 3, 4, 5, 6], name="a")
+    pdf2 = pd.DataFrame(
+        {"a": [1, 2, 3, 4, 5, 6], "b": 1}, index=pd.Index([1, 2, 3, 4, 5, 6], name="a")
     )
     df2 = from_pandas(pdf2, npartitions=2)
 
-    pdf3 = lib.DataFrame({"c": [1, 2, 3], "d": 1}, index=lib.Index([1, 2, 3], name="a"))
+    pdf3 = pd.DataFrame({"c": [1, 2, 3], "d": 1}, index=pd.Index([1, 2, 3], name="a"))
     df3 = from_pandas(pdf3, npartitions=2)
 
     result = df.join([df2, df3], how="outer")
@@ -157,7 +157,7 @@ def test_join_recursive():
 
 
 def test_join_recursive_raises():
-    pdf = lib.DataFrame({"x": [1, 2, 3], "y": 1}, index=lib.Index([1, 2, 3], name="a"))
+    pdf = pd.DataFrame({"x": [1, 2, 3], "y": 1}, index=pd.Index([1, 2, 3], name="a"))
     df = from_pandas(pdf, npartitions=2)
     with pytest.raises(ValueError, match="other must be DataFrame"):
         df.join(["dummy"])
@@ -169,7 +169,7 @@ def test_join_recursive_raises():
 
 
 def test_singleton_divisions():
-    df = lib.DataFrame({"x": [1, 1, 1]}, index=[1, 2, 3])
+    df = pd.DataFrame({"x": [1, 1, 1]}, index=[1, 2, 3])
     ddf = from_pandas(df, npartitions=2)
     ddf2 = ddf.set_index("x")
 
@@ -179,8 +179,8 @@ def test_singleton_divisions():
 
 
 def test_categorical_merge_does_not_increase_npartitions():
-    df1 = lib.DataFrame(data={"A": ["a", "b", "c"]}, index=["s", "v", "w"])
-    df2 = lib.DataFrame(data={"B": ["t", "d", "i"]}, index=["v", "w", "r"])
+    df1 = pd.DataFrame(data={"A": ["a", "b", "c"]}, index=["s", "v", "w"])
+    df2 = pd.DataFrame(data={"B": ["t", "d", "i"]}, index=["v", "w", "r"])
     # We are npartitions=1 on both sides, so it should stay that way
     ddf1 = from_pandas(df1, npartitions=1)
     df2 = df2.astype({"B": "category"})
@@ -188,9 +188,9 @@ def test_categorical_merge_does_not_increase_npartitions():
 
 
 def test_merge_len():
-    pdf = lib.DataFrame({"x": [1, 2, 3], "y": 1})
+    pdf = pd.DataFrame({"x": [1, 2, 3], "y": 1})
     df = from_pandas(pdf, npartitions=2)
-    pdf2 = lib.DataFrame({"x": [1, 2, 3], "z": 1})
+    pdf2 = pd.DataFrame({"x": [1, 2, 3], "z": 1})
     df2 = from_pandas(pdf2, npartitions=2)
     assert_eq(len(df.merge(df2)), len(pdf.merge(pdf2)))
     query = df.merge(df2).index.optimize(fuse=False)
@@ -199,8 +199,8 @@ def test_merge_len():
 
 
 def test_merge_optimize_subset_strings():
-    pdf = lib.DataFrame({"a": [1, 2], "aaa": 1})
-    pdf2 = lib.DataFrame({"b": [1, 2], "aaa": 1})
+    pdf = pd.DataFrame({"a": [1, 2], "aaa": 1})
+    pdf2 = pd.DataFrame({"b": [1, 2], "aaa": 1})
     df = from_pandas(pdf)
     df2 = from_pandas(pdf2)
 
@@ -212,7 +212,7 @@ def test_merge_optimize_subset_strings():
 
 @pytest.mark.parametrize("npartitions_left, npartitions_right", [(2, 3), (1, 1)])
 def test_merge_combine_similar(npartitions_left, npartitions_right):
-    pdf = lib.DataFrame(
+    pdf = pd.DataFrame(
         {
             "a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             "b": 1,
@@ -222,7 +222,7 @@ def test_merge_combine_similar(npartitions_left, npartitions_right):
             "f": 1,
         }
     )
-    pdf2 = lib.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "x": 1})
+    pdf2 = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "x": 1})
 
     df = from_pandas(pdf, npartitions=npartitions_left)
     df2 = from_pandas(pdf2, npartitions=npartitions_right)
@@ -241,15 +241,15 @@ def test_merge_combine_similar(npartitions_left, npartitions_right):
 
 
 def test_merge_combine_similar_intermediate_projections():
-    pdf = lib.DataFrame(
+    pdf = pd.DataFrame(
         {
             "a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             "b": 1,
             "c": 1,
         }
     )
-    pdf2 = lib.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "x": 1})
-    pdf3 = lib.DataFrame({"d": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "e": 1, "y": 1})
+    pdf2 = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "x": 1})
+    pdf3 = pd.DataFrame({"d": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "e": 1, "y": 1})
 
     df = from_pandas(pdf, npartitions=2)
     df2 = from_pandas(pdf2, npartitions=3)
@@ -276,7 +276,7 @@ def test_merge_combine_similar_hangs():
     var2 = "BRASS"
     var3 = "EUROPE"
     region_ds = from_pandas(
-        lib.DataFrame.from_dict(
+        pd.DataFrame.from_dict(
             {
                 "r_regionkey": {0: 0, 1: 1},
                 "r_name": {0: "AFRICA", 1: "AMERICA"},
@@ -285,7 +285,7 @@ def test_merge_combine_similar_hangs():
         )
     )
     nation_filtered = from_pandas(
-        lib.DataFrame.from_dict(
+        pd.DataFrame.from_dict(
             {
                 "n_nationkey": {0: 0, 1: 1},
                 "n_name": {0: "ALGERIA", 1: "ARGENTINA"},
@@ -296,7 +296,7 @@ def test_merge_combine_similar_hangs():
     )
 
     supplier_filtered = from_pandas(
-        lib.DataFrame.from_dict(
+        pd.DataFrame.from_dict(
             {
                 "s_suppkey": {0: 1, 1: 2},
                 "s_name": {0: "a#1", 1: "a#2"},
@@ -309,7 +309,7 @@ def test_merge_combine_similar_hangs():
         )
     )
     part_filtered = from_pandas(
-        lib.DataFrame.from_dict(
+        pd.DataFrame.from_dict(
             {
                 "p_partkey": {0: 1, 1: 2},
                 "p_name": {0: "gol", 1: "bl"},
@@ -325,7 +325,7 @@ def test_merge_combine_similar_hangs():
     )
     #
     partsupp_filtered = from_pandas(
-        lib.DataFrame.from_dict(
+        pd.DataFrame.from_dict(
             {
                 "ps_partkey": {0: 1, 1: 1},
                 "ps_suppkey": {0: 2, 1: 2502},
@@ -376,7 +376,7 @@ def test_merge_combine_similar_hangs():
             "s_comment",
         ]
     ]
-    expected = lib.DataFrame(
+    expected = pd.DataFrame(
         columns=[
             "s_acctbal",
             "s_name",
@@ -398,21 +398,21 @@ def test_merge_combine_similar_hangs():
 def test_recursive_join():
     dfs_to_merge = []
     for i in range(10):
-        df = lib.DataFrame(
+        df = pd.DataFrame(
             {
                 f"{i}A": [5, 6, 7, 8],
                 f"{i}B": [4, 3, 2, 1],
             },
-            index=lib.Index([0, 1, 2, 3], name="a"),
+            index=pd.Index([0, 1, 2, 3], name="a"),
         )
         ddf = from_pandas(df, 2)
         dfs_to_merge.append(ddf)
 
-    ddf_loop = from_pandas(lib.DataFrame(index=lib.Index([0, 1, 3], name="a")), 3)
+    ddf_loop = from_pandas(pd.DataFrame(index=pd.Index([0, 1, 3], name="a")), 3)
     for ddf in dfs_to_merge:
         ddf_loop = ddf_loop.join(ddf, how="left")
 
-    ddf_pairwise = from_pandas(lib.DataFrame(index=lib.Index([0, 1, 3], name="a")), 3)
+    ddf_pairwise = from_pandas(pd.DataFrame(index=pd.Index([0, 1, 3], name="a")), 3)
 
     ddf_pairwise = ddf_pairwise.join(dfs_to_merge, how="left")
 
@@ -421,8 +421,8 @@ def test_recursive_join():
 
 
 def test_merge_repartition():
-    pdf = lib.DataFrame({"a": [1, 2, 3]})
-    pdf2 = lib.DataFrame({"b": [1, 2, 3]}, index=[1, 2, 3])
+    pdf = pd.DataFrame({"a": [1, 2, 3]})
+    pdf2 = pd.DataFrame({"b": [1, 2, 3]}, index=[1, 2, 3])
 
     df = from_pandas(pdf, npartitions=2)
     df2 = from_pandas(pdf2, npartitions=3)
@@ -430,9 +430,9 @@ def test_merge_repartition():
 
 
 def test_merge_reparititon_divisions():
-    pdf = lib.DataFrame({"a": [1, 2, 3, 4, 5, 6]})
-    pdf2 = lib.DataFrame({"b": [1, 2, 3, 4, 5, 6]}, index=[1, 2, 3, 4, 5, 6])
-    pdf3 = lib.DataFrame({"c": [1, 2, 3, 4, 5, 6]}, index=[1, 2, 3, 4, 5, 6])
+    pdf = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6]})
+    pdf2 = pd.DataFrame({"b": [1, 2, 3, 4, 5, 6]}, index=[1, 2, 3, 4, 5, 6])
+    pdf3 = pd.DataFrame({"c": [1, 2, 3, 4, 5, 6]}, index=[1, 2, 3, 4, 5, 6])
 
     df = from_pandas(pdf, npartitions=2)
     df2 = from_pandas(pdf2, npartitions=3)
@@ -442,10 +442,10 @@ def test_merge_reparititon_divisions():
 
 
 def test_join_gives_proper_divisions():
-    df = lib.DataFrame({"a": ["a", "b", "c"]}, index=[0, 1, 2])
+    df = pd.DataFrame({"a": ["a", "b", "c"]}, index=[0, 1, 2])
     ddf = from_pandas(df, npartitions=1)
 
-    right_df = lib.DataFrame({"b": [1.0, 2.0, 3.0]}, index=["a", "b", "c"])
+    right_df = pd.DataFrame({"b": [1.0, 2.0, 3.0]}, index=["a", "b", "c"])
 
     expected = df.join(right_df, how="inner", on="a")
     actual = ddf.join(right_df, how="inner", on="a")
@@ -461,13 +461,13 @@ def test_merge_known_to_single(how, shuffle_method):
     idx = [i for i, s in enumerate(partition_sizes) for _ in range(s)]
     k = [i for s in partition_sizes for i in range(s)]
     vi = range(len(k))
-    pdf1 = lib.DataFrame(dict(idx=idx, k=k, v1=vi)).set_index(["idx"])
+    pdf1 = pd.DataFrame(dict(idx=idx, k=k, v1=vi)).set_index(["idx"])
 
     partition_sizes = np.array([4, 2, 5, 3, 2, 5, 9, 4, 7, 4, 8])
     idx = [i for i, s in enumerate(partition_sizes) for _ in range(s)]
     k = [i for s in partition_sizes for i in range(s)]
     vi = range(len(k))
-    pdf2 = lib.DataFrame(dict(idx=idx, k=k, v1=vi)).set_index(["idx"])
+    pdf2 = pd.DataFrame(dict(idx=idx, k=k, v1=vi)).set_index(["idx"])
 
     df1 = repartition(pdf1, [0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11])
     df2 = from_pandas(pdf2, npartitions=1, sort=False)
@@ -485,8 +485,8 @@ def test_merge_known_to_single(how, shuffle_method):
 
 @pytest.mark.parametrize("how", ["right", "outer"])
 def test_merge_empty_left_df(how):
-    left = lib.DataFrame({"a": [1, 1, 2, 2], "val": [5, 6, 7, 8]})
-    right = lib.DataFrame({"a": [0, 0, 3, 3], "val": [11, 12, 13, 14]})
+    left = pd.DataFrame({"a": [1, 1, 2, 2], "val": [5, 6, 7, 8]})
+    right = pd.DataFrame({"a": [0, 0, 3, 3], "val": [11, 12, 13, 14]})
 
     dd_left = from_pandas(left, npartitions=4)
     dd_right = from_pandas(right, npartitions=4)
@@ -500,8 +500,8 @@ def test_merge_empty_left_df(how):
 
 
 def test_merge_npartitions():
-    pdf = lib.DataFrame({"a": [1, 2, 3, 4, 5, 6]})
-    pdf2 = lib.DataFrame({"b": [1, 2, 3, 4, 5, 6]}, index=[1, 2, 3, 4, 5, 6])
+    pdf = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6]})
+    pdf2 = pd.DataFrame({"b": [1, 2, 3, 4, 5, 6]}, index=[1, 2, 3, 4, 5, 6])
     df = from_pandas(pdf, npartitions=1)
     df2 = from_pandas(pdf2, npartitions=3)
 
@@ -516,11 +516,11 @@ def test_merge_npartitions():
     assert result.npartitions == 4
     assert_eq(result, pdf.join(pdf2))
 
-    pdf = lib.DataFrame(
-        {"a": [1, 2, 3, 4, 5, 6]}, index=lib.Index([6, 5, 4, 3, 2, 1], name="a")
+    pdf = pd.DataFrame(
+        {"a": [1, 2, 3, 4, 5, 6]}, index=pd.Index([6, 5, 4, 3, 2, 1], name="a")
     )
-    pdf2 = lib.DataFrame(
-        {"b": [1, 2, 3, 4, 5, 6]}, index=lib.Index([1, 2, 7, 4, 5, 6], name="a")
+    pdf2 = pd.DataFrame(
+        {"b": [1, 2, 3, 4, 5, 6]}, index=pd.Index([1, 2, 7, 4, 5, 6], name="a")
     )
     df = from_pandas(pdf, npartitions=2, sort=False)
     df2 = from_pandas(pdf2, npartitions=3, sort=False)
@@ -537,10 +537,10 @@ def test_merge_columns_dtypes1(how, on_index):
     # asserts that either the merge was successful or the corresponding warning is raised
     # addresses issue #4574
 
-    df1 = lib.DataFrame(
+    df1 = pd.DataFrame(
         {"A": list(np.arange(5).astype(float)) * 2, "B": list(np.arange(5)) * 2}
     )
-    df2 = lib.DataFrame({"A": np.arange(5), "B": np.arange(5)})
+    df2 = pd.DataFrame({"A": np.arange(5), "B": np.arange(5)})
 
     a = from_pandas(df1, 2)  # merge column "A" is float
     b = from_pandas(df2, 2)  # merge column "A" is int
@@ -561,21 +561,21 @@ def test_merge_columns_dtypes1(how, on_index):
         warned = any("merge column data type mismatches" in str(r) for r in record)
 
     # result type depends on merge operation -> convert to pandas
-    result = result if isinstance(result, lib.DataFrame) else result.compute()
+    result = result if isinstance(result, pd.DataFrame) else result.compute()
 
     has_nans = result.isna().values.any()
     assert (has_nans and warned) or not has_nans
 
 
 def test_merge_pandas_object():
-    pdf1 = lib.DataFrame({"x": range(20), "y": range(20)})
+    pdf1 = pd.DataFrame({"x": range(20), "y": range(20)})
     df1 = from_pandas(pdf1, 4)
-    pdf2 = lib.DataFrame({"x": range(20), "z": range(20)})
+    pdf2 = pd.DataFrame({"x": range(20), "z": range(20)})
 
     assert_eq(merge(df1, pdf2, on="x"), pdf1.merge(pdf2, on="x"), check_index=False)
     assert_eq(merge(pdf2, df1, on="x"), pdf2.merge(pdf1, on="x"), check_index=False)
 
-    pdf1 = lib.DataFrame({"x": range(20), "y": range(20)}).set_index("x")
+    pdf1 = pd.DataFrame({"x": range(20), "y": range(20)}).set_index("x")
     df1 = from_pandas(pdf1, 4)
     assert_eq(
         merge(df1, pdf2, left_index=True, right_on="x"),
@@ -597,7 +597,7 @@ def test_pairwise_merge_results_in_identical_output_df(
 ):
     dfs_to_merge = []
     for i in range(10):
-        df = lib.DataFrame(
+        df = pd.DataFrame(
             {
                 f"{i}A": [5, 6, 7, 8],
                 f"{i}B": [4, 3, 2, 1],
@@ -607,11 +607,11 @@ def test_pairwise_merge_results_in_identical_output_df(
         ddf = from_pandas(df, npartitions_other)
         dfs_to_merge.append(ddf)
 
-    ddf_loop = from_pandas(lib.DataFrame(index=[0, 1, 3]), npartitions_base)
+    ddf_loop = from_pandas(pd.DataFrame(index=[0, 1, 3]), npartitions_base)
     for ddf in dfs_to_merge:
         ddf_loop = ddf_loop.join(ddf, how=how)
 
-    ddf_pairwise = from_pandas(lib.DataFrame(index=[0, 1, 3]), npartitions_base)
+    ddf_pairwise = from_pandas(pd.DataFrame(index=[0, 1, 3]), npartitions_base)
 
     ddf_pairwise = ddf_pairwise.join(dfs_to_merge, how=how)
 

--- a/dask_expr/tests/test_quantiles.py
+++ b/dask_expr/tests/test_quantiles.py
@@ -2,18 +2,18 @@ from dask_expr import from_pandas
 from dask_expr.tests._util import _backend_library, assert_eq
 
 # Set DataFrame backend for this module
-lib = _backend_library()
+pd = _backend_library()
 
 
 def test_repartition_quantiles():
-    pdf = lib.DataFrame({"a": [1, 2, 3, 4, 5, 15, 7, 8, 9, 10, 11], "d": 3})
+    pdf = pd.DataFrame({"a": [1, 2, 3, 4, 5, 15, 7, 8, 9, 10, 11], "d": 3})
     df = from_pandas(pdf, npartitions=5)
     result = df.a._repartition_quantiles(npartitions=5)
-    expected = lib.Series(
+    expected = pd.Series(
         [1, 1, 3, 7, 9, 15], index=[0, 0.2, 0.4, 0.6, 0.8, 1], name="a"
     )
     assert_eq(result, expected)
 
     result = df.a._repartition_quantiles(npartitions=4)
-    expected = lib.Series([1, 2, 5, 8, 15], index=[0, 0.25, 0.5, 0.75, 1], name="a")
+    expected = pd.Series([1, 2, 5, 8, 15], index=[0, 0.25, 0.5, 0.75, 1], name="a")
     assert_eq(result, expected)

--- a/dask_expr/tests/test_reductions.py
+++ b/dask_expr/tests/test_reductions.py
@@ -9,12 +9,12 @@ from dask_expr._util import DASK_GT_20231201
 from dask_expr.tests._util import _backend_library, assert_eq, xfail_gpu
 
 # Set DataFrame backend for this module
-lib = _backend_library()
+pd = _backend_library()
 
 
 @pytest.fixture
 def pdf():
-    pdf = lib.DataFrame({"x": range(100)})
+    pdf = pd.DataFrame({"x": range(100)})
     pdf["y"] = pdf.x // 7  # Not unique; duplicates span different partitions
     yield pdf
 
@@ -67,7 +67,7 @@ def test_min_dt(pdf):
 def test_monotonic(series, reverse, cls):
     if reverse:
         series = series[::-1]
-    pds = lib.Series(series, index=series)
+    pds = pd.Series(series, index=series)
     ds = from_pandas(pds, 2, sort=False)
     if cls == "Index":
         pds = pds.index
@@ -109,7 +109,7 @@ def test_value_counts(pdf, df, split_every, split_out):
 def test_unique(pdf, df, split_every, split_out):
     assert_eq(
         df.x.unique(split_every=split_every, split_out=split_out),
-        lib.Series(pdf.x.unique(), name="x"),
+        pd.Series(pdf.x.unique(), name="x"),
         check_index=split_out is not True,
     )
 
@@ -197,11 +197,11 @@ def test_unique_base(df, pdf):
         df.unique()
 
     # pandas returns a numpy array while we return a Series/Index
-    assert_eq(df.x.unique(), lib.Series(pdf.x.unique(), name="x"), check_index=False)
-    assert_eq(df.index.unique(split_out=1), lib.Index(pdf.index.unique()))
+    assert_eq(df.x.unique(), pd.Series(pdf.x.unique(), name="x"), check_index=False)
+    assert_eq(df.index.unique(split_out=1), pd.Index(pdf.index.unique()))
     np.testing.assert_array_equal(
         df.index.unique().compute().sort_values().values,
-        lib.Index(pdf.index.unique()).values,
+        pd.Index(pdf.index.unique()).values,
     )
 
 
@@ -215,7 +215,7 @@ def test_value_counts_split_out_normalize(df, pdf):
 @pytest.mark.parametrize("method", ["sum", "prod", "product"])
 @pytest.mark.parametrize("min_count", [0, 9])
 def test_series_agg_with_min_count(method, min_count):
-    df = lib.DataFrame([[1]], columns=["a"])
+    df = pd.DataFrame([[1]], columns=["a"])
     ddf = from_pandas(df, npartitions=1)
     func = getattr(ddf["a"], method)
     result = func(min_count=min_count).compute()
@@ -308,7 +308,7 @@ def test_unimplemented_on_index(func, pdf, df):
 
 
 def test_reduction_on_empty_df():
-    pdf = lib.DataFrame()
+    pdf = pd.DataFrame()
     df = from_pandas(pdf)
     assert_eq(df.sum(), pdf.sum())
 
@@ -325,7 +325,7 @@ def test_reduction_on_empty_df():
 )
 @pytest.mark.parametrize("ddof", [1, 2])
 def test_std_kwargs(axis, skipna, ddof):
-    pdf = lib.DataFrame(
+    pdf = pd.DataFrame(
         {"x": range(30), "y": [1, 2, None] * 10, "z": ["dog", "cat"] * 15}
     )
     df = from_pandas(pdf, npartitions=3)

--- a/dask_expr/tests/test_repartition.py
+++ b/dask_expr/tests/test_repartition.py
@@ -4,7 +4,7 @@ import pytest
 from dask_expr import Repartition, from_pandas, repartition
 from dask_expr.tests._util import _backend_library, assert_eq
 
-lib = _backend_library()
+pd = _backend_library()
 
 
 @pytest.mark.parametrize(
@@ -17,7 +17,7 @@ lib = _backend_library()
     ],
 )
 def test_repartition_combine_similar(kwargs):
-    pdf = lib.DataFrame({"x": [1, 2, 3, 4, 5, 6, 7, 8] * 10, "y": 1, "z": 2})
+    pdf = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6, 7, 8] * 10, "y": 1, "z": 2})
     df = from_pandas(pdf, npartitions=3)
     query = df.repartition(**kwargs)
     query["new"] = query.x + query.y
@@ -36,7 +36,7 @@ def test_repartition_combine_similar(kwargs):
 
 @pytest.mark.parametrize("type_ctor", [lambda o: o, tuple, list])
 def test_repartition_noop(type_ctor):
-    pdf = lib.DataFrame({"x": [1, 2, 4, 5], "y": [6, 7, 8, 9]}, index=[-1, 0, 2, 7])
+    pdf = pd.DataFrame({"x": [1, 2, 4, 5], "y": [6, 7, 8, 9]}, index=[-1, 0, 2, 7])
     df = from_pandas(pdf, npartitions=2)
     ds = df.x
 
@@ -64,8 +64,8 @@ def test_repartition_noop(type_ctor):
 
 
 def test_repartition_freq():
-    ts = lib.date_range("2015-01-01 00:00", "2015-05-01 23:50", freq="10min")
-    pdf = lib.DataFrame(
+    ts = pd.date_range("2015-01-01 00:00", "2015-05-01 23:50", freq="10min")
+    pdf = pd.DataFrame(
         np.random.randint(0, 100, size=(len(ts), 4)), columns=list("ABCD"), index=ts
     )
     df = from_pandas(pdf, npartitions=1).repartition(freq="MS")
@@ -73,19 +73,19 @@ def test_repartition_freq():
     assert_eq(df, pdf)
 
     assert df.divisions == (
-        lib.Timestamp("2015-1-1 00:00:00"),
-        lib.Timestamp("2015-2-1 00:00:00"),
-        lib.Timestamp("2015-3-1 00:00:00"),
-        lib.Timestamp("2015-4-1 00:00:00"),
-        lib.Timestamp("2015-5-1 00:00:00"),
-        lib.Timestamp("2015-5-1 23:50:00"),
+        pd.Timestamp("2015-1-1 00:00:00"),
+        pd.Timestamp("2015-2-1 00:00:00"),
+        pd.Timestamp("2015-3-1 00:00:00"),
+        pd.Timestamp("2015-4-1 00:00:00"),
+        pd.Timestamp("2015-5-1 00:00:00"),
+        pd.Timestamp("2015-5-1 23:50:00"),
     )
 
     assert df.npartitions == 5
 
 
 def test_repartition_freq_errors():
-    pdf = lib.DataFrame({"x": [1, 2, 3]})
+    pdf = pd.DataFrame({"x": [1, 2, 3]})
     df = from_pandas(pdf, npartitions=1)
     with pytest.raises(TypeError, match="for timeseries"):
         df.repartition(freq="1s")
@@ -96,7 +96,7 @@ def test_repartition_npartitions_numeric_edge_case():
     Test that we cover numeric edge cases when
     int(ddf.npartitions / npartitions) * npartitions) != ddf.npartitions
     """
-    df = lib.DataFrame({"x": range(100)})
+    df = pd.DataFrame({"x": range(100)})
     a = from_pandas(df, npartitions=15)
     assert a.npartitions == 15
     b = a.repartition(npartitions=11)
@@ -104,7 +104,7 @@ def test_repartition_npartitions_numeric_edge_case():
 
 
 def test_repartition_empty_partitions_dtype():
-    pdf = lib.DataFrame({"x": [1, 2, 3, 4, 5, 6, 7, 8]})
+    pdf = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6, 7, 8]})
     df = from_pandas(pdf, npartitions=4)
     assert_eq(
         df[df.x < 5].repartition(npartitions=1),

--- a/dask_expr/tests/test_resample.py
+++ b/dask_expr/tests/test_resample.py
@@ -6,7 +6,7 @@ from dask_expr import from_pandas
 from dask_expr.tests._util import _backend_library, assert_eq
 
 # Set DataFrame backend for this module
-lib = _backend_library()
+pd = _backend_library()
 
 
 def resample(df, freq, how="mean", **kwargs):
@@ -15,8 +15,8 @@ def resample(df, freq, how="mean", **kwargs):
 
 @pytest.fixture
 def pdf():
-    idx = lib.date_range("2000-01-01", periods=12, freq="T")
-    pdf = lib.DataFrame({"foo": range(len(idx))}, index=idx)
+    idx = pd.date_range("2000-01-01", periods=12, freq="T")
+    pdf = pd.DataFrame({"foo": range(len(idx))}, index=idx)
     pdf["bar"] = 1
     yield pdf
 
@@ -80,12 +80,12 @@ def test_resample_apis(df, pdf, api, kwargs):
     ),
 )
 def test_series_resample(obj, method, npartitions, freq, closed, label):
-    index = lib.date_range("1-1-2000", "2-15-2000", freq="h")
-    index = index.union(lib.date_range("4-15-2000", "5-15-2000", freq="h"))
+    index = pd.date_range("1-1-2000", "2-15-2000", freq="h")
+    index = index.union(pd.date_range("4-15-2000", "5-15-2000", freq="h"))
     if obj == "series":
-        ps = lib.Series(range(len(index)), index=index)
+        ps = pd.Series(range(len(index)), index=index)
     elif obj == "frame":
-        ps = lib.DataFrame({"a": range(len(index))}, index=index)
+        ps = pd.DataFrame({"a": range(len(index))}, index=index)
     ds = from_pandas(ps, npartitions=npartitions)
     # Series output
 
@@ -120,9 +120,9 @@ def test_resample_agg(df, pdf):
 
 @pytest.mark.parametrize("method", ["count", "nunique", "size", "sum"])
 def test_resample_has_correct_fill_value(method):
-    index = lib.date_range("2000-01-01", "2000-02-15", freq="h")
-    index = index.union(lib.date_range("4-15-2000", "5-15-2000", freq="h"))
-    ps = lib.Series(range(len(index)), index=index)
+    index = pd.date_range("2000-01-01", "2000-02-15", freq="h")
+    index = index.union(pd.date_range("4-15-2000", "5-15-2000", freq="h"))
+    ps = pd.Series(range(len(index)), index=index)
     ds = from_pandas(ps, npartitions=2)
 
     assert_eq(

--- a/dask_expr/tests/test_reshape.py
+++ b/dask_expr/tests/test_reshape.py
@@ -4,15 +4,15 @@ from dask_expr import from_pandas, pivot_table
 from dask_expr.tests._util import _backend_library, assert_eq
 
 # Set DataFrame backend for this module
-lib = _backend_library()
+pd = _backend_library()
 
 
 @pytest.fixture
 def pdf():
-    pdf = lib.DataFrame(
+    pdf = pd.DataFrame(
         {
             "x": [1, 2, 3, 4, 5, 6],
-            "y": lib.Series([4, 5, 8, 6, 1, 4], dtype="category"),
+            "y": pd.Series([4, 5, 8, 6, 1, 4], dtype="category"),
             "z": [4, 15, 8, 16, 1, 14],
             "a": 1,
         }

--- a/dask_expr/tests/test_rolling.py
+++ b/dask_expr/tests/test_rolling.py
@@ -6,13 +6,13 @@ from dask_expr import from_pandas
 from dask_expr.tests._util import _backend_library, assert_eq
 
 # Set DataFrame backend for this module
-lib = _backend_library()
+pd = _backend_library()
 
 
 @pytest.fixture
 def pdf():
-    idx = lib.date_range("2000-01-01", periods=12, freq="T")
-    pdf = lib.DataFrame({"foo": range(len(idx))}, index=idx)
+    idx = pd.date_range("2000-01-01", periods=12, freq="T")
+    pdf = pd.DataFrame({"foo": range(len(idx))}, index=idx)
     pdf["bar"] = 1
     yield pdf
 
@@ -111,7 +111,7 @@ def test_rolling_apply(df, pdf, window, raw, foo, bar):
 
 
 def test_rolling_one_element_window(df, pdf):
-    pdf.index = lib.date_range("2000-01-01", periods=12, freq="2s")
+    pdf.index = pd.date_range("2000-01-01", periods=12, freq="2s")
     df = from_pandas(pdf, npartitions=3)
     result = pdf.foo.rolling("1s").count()
     expected = df.foo.rolling("1s").count()
@@ -119,7 +119,7 @@ def test_rolling_one_element_window(df, pdf):
 
 
 def test_rolling_one_element_window_empty_after(df, pdf):
-    pdf.index = lib.date_range("2000-01-01", periods=12, freq="2s")
+    pdf.index = pd.date_range("2000-01-01", periods=12, freq="2s")
     df = from_pandas(pdf, npartitions=3)
     result = df.map_overlap(lambda x: x.rolling("1s").count(), before="1s", after="1s")
     expected = pdf.rolling("1s").count()

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -13,12 +13,12 @@ from dask_expr.io import FromPandas
 from dask_expr.tests._util import _backend_library, assert_eq
 
 # Set DataFrame backend for this module
-lib = _backend_library()
+pd = _backend_library()
 
 
 @pytest.fixture
 def pdf():
-    return lib.DataFrame({"x": list(range(20)) * 5, "y": range(100)})
+    return pd.DataFrame({"x": list(range(20)) * 5, "y": range(100)})
 
 
 @pytest.fixture
@@ -146,7 +146,7 @@ def test_shuffle_reductions_after_projection(df):
 @pytest.mark.parametrize("nelem", [10, 500])
 def test_sort_values_(nelem, by, ascending):
     np.random.seed(0)
-    df = lib.DataFrame()
+    df = pd.DataFrame()
     df["a"] = np.ascontiguousarray(np.arange(nelem)[::-1])
     df["b"] = np.arange(100, nelem + 100)
     ddf = from_pandas(df, npartitions=10)
@@ -163,7 +163,7 @@ def test_sort_values_(nelem, by, ascending):
 @pytest.mark.parametrize("nelem", [10, 500])
 def test_sort_values_single_partition(nelem, by, ascending):
     np.random.seed(0)
-    df = lib.DataFrame()
+    df = pd.DataFrame()
     df["a"] = np.ascontiguousarray(np.arange(nelem)[::-1])
     df["b"] = np.arange(100, nelem + 100)
     ddf = from_pandas(df, npartitions=1)
@@ -242,7 +242,7 @@ def test_set_index_pre_sorted(pdf):
 @pytest.mark.parametrize("drop", (True, False))
 @pytest.mark.parametrize("append", (True, False))
 def test_set_index_no_sort(drop, append):
-    df = lib.DataFrame({"col1": [2, 4, 1, 3, 5], "col2": [1, 2, 3, 4, 5]})
+    df = pd.DataFrame({"col1": [2, 4, 1, 3, 5], "col2": [1, 2, 3, 4, 5]})
     ddf = from_pandas(df, npartitions=2)
 
     assert ddf.npartitions > 1
@@ -281,7 +281,7 @@ def test_set_index_simplify(df, pdf):
 
 
 def test_set_index_numeric_columns():
-    pdf = lib.DataFrame(
+    pdf = pd.DataFrame(
         {
             0: list("ABAABBABAA"),
             1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
@@ -334,7 +334,7 @@ def test_sort_values(df, pdf, shuffle):
 
 @pytest.mark.parametrize("shuffle", [None, "tasks"])
 def test_sort_values_temporary_column_dropped(shuffle):
-    pdf = lib.DataFrame(
+    pdf = pd.DataFrame(
         {"x": range(10), "y": [1, 2, 3, 4, 5] * 2, "z": ["cat", "dog"] * 5}
     )
     df = from_pandas(pdf, npartitions=2)
@@ -441,7 +441,7 @@ def test_filter_sort(df):
 
 
 def test_sort_values_add():
-    pdf = lib.DataFrame({"x": [1, 2, 3, 0, 1, 2, 4, 5], "y": 1})
+    pdf = pd.DataFrame({"x": [1, 2, 3, 0, 1, 2, 4, 5], "y": 1})
     df = from_pandas(pdf, npartitions=2, sort=False)
     with dask.config.set({"dataframe.shuffle.method": "tasks"}):
         df = df.sort_values("x")
@@ -451,10 +451,10 @@ def test_sort_values_add():
         assert_eq(df, pdf, sort_results=False)
 
 
-@pytest.mark.parametrize("null_value", [None, lib.NaT, lib.NA])
+@pytest.mark.parametrize("null_value", [None, pd.NaT, pd.NA])
 def test_index_nulls(null_value):
     "Setting the index with some non-numeric null raises error"
-    df = lib.DataFrame(
+    df = pd.DataFrame(
         {"numeric": [1, 2, 3, 4], "non_numeric": ["foo", "bar", "foo", "bar"]}
     )
     ddf = from_pandas(df, npartitions=2)
@@ -472,15 +472,15 @@ def test_set_index_with_dask_dt_index(freq):
         "y": [10, 20, 30] * 4,
         "name": ["Alice", "Bob"] * 6,
     }
-    date_index = lib.date_range(
+    date_index = pd.date_range(
         start="2022-02-22", freq=freq, periods=12
-    ) - lib.Timedelta(seconds=30)
-    df = lib.DataFrame(values, index=date_index)
+    ) - pd.Timedelta(seconds=30)
+    df = pd.DataFrame(values, index=date_index)
     ddf = from_pandas(df, npartitions=3, sort=False)
     # specify a different date index entirely
     day_index = ddf.index.dt.floor("D")
     result = ddf.set_index(day_index)
-    assert_eq(result, lib.DataFrame(values, index=date_index.floor("D")))
+    assert_eq(result, pd.DataFrame(values, index=date_index.floor("D")))
 
 
 def test_set_index_sort_values_shuffle_options(df, pdf):
@@ -512,7 +512,7 @@ def test_set_index_predicate_pushdown(df, pdf):
 
 
 def test_set_index_with_explicit_divisions():
-    pdf = lib.DataFrame({"x": [4, 1, 2, 5]}, index=[10, 20, 30, 40])
+    pdf = pd.DataFrame({"x": [4, 1, 2, 5]}, index=[10, 20, 30, 40])
 
     df = from_pandas(pdf, npartitions=2)
 
@@ -578,7 +578,7 @@ def test_shuffle(df, pdf):
 
 def test_empty_partitions():
     # See https://github.com/dask/dask/issues/2408
-    df = lib.DataFrame({"a": list(range(10))})
+    df = pd.DataFrame({"a": list(range(10))})
     df["b"] = df["a"] % 3
     df["c"] = df["b"].astype(str)
 

--- a/dask_expr/tests/test_string_accessor.py
+++ b/dask_expr/tests/test_string_accessor.py
@@ -5,12 +5,12 @@ from dask.dataframe._compat import PANDAS_GE_200
 from dask_expr._collection import from_pandas
 from dask_expr.tests._util import _backend_library, assert_eq
 
-lib = _backend_library()
+pd = _backend_library()
 
 
 @pytest.fixture()
 def ser():
-    return lib.Series(["a", "b", "1", "aaa", "bbb", "ccc", "ddd", "abcd"])
+    return pd.Series(["a", "b", "1", "aaa", "bbb", "ccc", "ddd", "abcd"])
 
 
 @pytest.fixture()
@@ -75,7 +75,7 @@ def dser(ser):
         ("split", {"pat": "a"}),
         ("rsplit", {"pat": "a"}),
         ("cat", {}),
-        ("cat", {"others": lib.Series(["a"])}),
+        ("cat", {"others": pd.Series(["a"])}),
     ],
 )
 def test_string_accessor(ser, dser, func, kwargs):
@@ -91,8 +91,8 @@ def test_string_accessor(ser, dser, func, kwargs):
         return
 
     if isinstance(pdf_result, np.ndarray):
-        pdf_result = lib.Index(pdf_result)
-    if isinstance(pdf_result, lib.DataFrame):
+        pdf_result = pd.Index(pdf_result)
+    if isinstance(pdf_result, pd.DataFrame):
         assert_eq(
             getattr(dser.index.str, func)(**kwargs), pdf_result, check_index=False
         )
@@ -117,7 +117,7 @@ def test_str_accessor_cat(ser, dser):
 
 @pytest.mark.parametrize("index", [None, [0]], ids=["range_index", "other index"])
 def test_str_split_(index):
-    df = lib.DataFrame({"a": ["a\nb"]}, index=index)
+    df = pd.DataFrame({"a": ["a\nb"]}, index=index)
     ddf = from_pandas(df, npartitions=1)
 
     pd_a = df["a"].str.split("\n", n=1, expand=True)
@@ -127,7 +127,7 @@ def test_str_split_(index):
 
 
 def test_str_accessor_not_available():
-    pdf = lib.DataFrame({"a": [1, 2, 3]})
+    pdf = pd.DataFrame({"a": [1, 2, 3]})
     df = from_pandas(pdf, npartitions=2)
     # Not available on invalid dtypes
     with pytest.raises(AttributeError, match=".str accessor"):


### PR DESCRIPTION
ref #525

I am copying a bunch of tests over from dask for various featrues/bugs and having to rename pd. to lib. all the time is very annoying. This preserves the dispatch mechanism, we just rename the variable