### PR TITLE
Remove outdated warning about P2P ordering stability

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -1652,13 +1652,11 @@ class DataFrame(FrameBase):
         split_every=None,
         split_out=True,
         shuffle_method=None,
-        keep=None,
+        keep="first",
     ):
         shuffle_method = _get_shuffle_preferring_order(shuffle_method)
         if keep is False:
             raise NotImplementedError("drop_duplicates with keep=False")
-        elif keep is None:
-            keep = "first"
         # Fail early if subset is not valid, e.g. missing columns
         subset = _convert_to_list(subset)
         meta_nonempty(self._meta).drop_duplicates(subset=subset, keep=keep)
@@ -2326,19 +2324,11 @@ class Series(FrameBase):
         split_every=None,
         split_out=True,
         shuffle_method=None,
-        keep=None,
+        keep="first",
     ):
         shuffle_method = _get_shuffle_preferring_order(shuffle_method)
         if keep is False:
             raise NotImplementedError("drop_duplicates with keep=False")
-        if keep is not None and shuffle_method == "p2p":
-            warnings.warn(
-                "P2P shuffle doesn't have ordering guarantees, so keep='first' and "
-                "keep='last' might return unexpected results",
-                UserWarning,
-            )
-        elif keep is None:
-            keep = "first"
         return new_collection(
             DropDuplicates(
                 self,

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -38,7 +38,6 @@ from dask.dataframe.utils import (
 from dask.utils import (
     IndexCallable,
     M,
-    get_default_shuffle_method,
     memory_repr,
     put_lines,
     random_state_data,
@@ -1658,12 +1657,6 @@ class DataFrame(FrameBase):
         shuffle_method = _get_shuffle_preferring_order(shuffle_method)
         if keep is False:
             raise NotImplementedError("drop_duplicates with keep=False")
-        if keep is not None and get_default_shuffle_method() == "p2p":
-            warnings.warn(
-                "P2P shuffle doesn't have ordering guarantees, so keep='first' and "
-                "keep='last' might return unexpected results",
-                UserWarning,
-            )
         elif keep is None:
             keep = "first"
         # Fail early if subset is not valid, e.g. missing columns

--- a/dask_expr/tests/test_distributed.py
+++ b/dask_expr/tests/test_distributed.py
@@ -335,17 +335,3 @@ def test_merge_combine_similar_squash_merges(add_repartition):
         out.reset_index(drop=True),
         expected,
     )
-
-
-@gen_cluster(client=True)
-async def test_p2p_drop_duplicates(c, s, a, b):
-    df = dx.datasets.timeseries(
-        start="2000-01-01",
-        end="2000-01-10",
-        dtypes={"x": float, "y": float},
-        freq="10 s",
-    )
-    with pytest.warns(UserWarning, match="keep"):
-        df.drop_duplicates(keep="first")
-    with pytest.warns(UserWarning, match="keep"):
-        df.x.drop_duplicates(keep="first")


### PR DESCRIPTION
With dask/distributed#8453, `p2p` has become stable for individual shuffle keys making `drop_duplicates(..., keep="{first|last}")` stable as well.