### PR TITLE
Use try block for ``is_any_real_numeric_dtype``

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -97,19 +97,13 @@ from dask_expr._util import (
     _BackendData,
     _convert_to_list,
     _get_shuffle_preferring_order,
+    _is_any_real_numeric_dtype,
     _maybe_from_pandas,
     _raise_if_object_series,
     _validate_axis,
     is_scalar,
 )
 from dask_expr.io import FromPandasDivisions, FromScalars
-
-# Temporary/soft pandas<2 support to enable cudf dev
-try:
-    from pandas.api.types import is_any_real_numeric_dtype
-except ImportError:
-    is_any_real_numeric_dtype = None
-
 
 #
 # Utilities to wrap Expr API
@@ -2660,9 +2654,7 @@ def from_pandas(data, npartitions=None, sort=True, chunksize=None):
     if not has_parallel_type(data):
         raise TypeError("Input must be a pandas DataFrame or Series.")
 
-    if is_any_real_numeric_dtype and (
-        data.index.isna().any() and not is_any_real_numeric_dtype(data.index)
-    ):
+    if data.index.isna().any() and not _is_any_real_numeric_dtype(data.index):
         raise NotImplementedError(
             "Index in passed data is non-numeric and contains nulls, which Dask does not entirely support.\n"
             "Consider passing `data.loc[~data.isna()]` instead."

--- a/dask_expr/_util.py
+++ b/dask_expr/_util.py
@@ -241,3 +241,20 @@ class RaiseAttributeError:
         raise AttributeError(
             f"{owner.__name__!r} object has no attribute {self.name!r}"
         )
+
+
+def _is_any_real_numeric_dtype(arr_or_dtype):
+    try:
+        from pandas.api.types import is_any_real_numeric_dtype
+
+        return is_any_real_numeric_dtype(arr_or_dtype)
+    except ImportError:
+        # Temporary/soft pandas<2 support to enable cudf dev
+        # TODO: Remove `try` block after 4/2024
+        from pandas.api.types import is_bool_dtype, is_complex_dtype, is_numeric_dtype
+
+        return (
+            is_numeric_dtype(arr_or_dtype)
+            and not is_complex_dtype(arr_or_dtype)
+            and not is_bool_dtype(arr_or_dtype)
+        )


### PR DESCRIPTION
https://github.com/dask-contrib/dask-expr/pull/705 added an `is_any_real_numeric_dtype` import. This makes sense, because dask-expr requires pandas>=2. However, I'd like to be able to develop with pandas-1.5 for a bit longer (even if many tests fail). This PR makes a minimal change so I can continue experimenting with ways to add/support backend dispatching.