### PR TITLE
Add basic backend dispatching to dask-expr

### DIFF
--- a/dask_expr/__init__.py
+++ b/dask_expr/__init__.py
@@ -1,5 +1,6 @@
 from dask_expr import _version, datasets
 from dask_expr._collection import *
+from dask_expr._dispatch import get_collection_type
 from dask_expr._dummies import get_dummies
 from dask_expr.io._delayed import from_delayed
 from dask_expr.io.bag import to_bag

--- a/dask_expr/_backends.py
+++ b/dask_expr/_backends.py
@@ -4,11 +4,31 @@ import pandas as pd
 from dask.backends import CreationDispatch
 from dask.dataframe.backends import DataFrameBackendEntrypoint
 
-dataframe_creation_dispatch = CreationDispatch(
+from dask_expr._dispatch import get_collection_type
+
+
+class DXCreationDispatch(CreationDispatch):
+    """Dask-expressions version of CreationDispatch"""
+
+    # TODO Remove after https://github.com/dask/dask/pull/10794
+    def dispatch(self, backend: str):
+        from dask.backends import detect_entrypoints
+
+        try:
+            impl = self._lookup[backend]
+        except KeyError:
+            entrypoints = detect_entrypoints(f"dask-expr.{self._module_name}.backends")
+            if backend in entrypoints:
+                return self.register_backend(backend, entrypoints[backend].load()())
+        else:
+            return impl
+        raise ValueError(f"No backend dispatch registered for {backend}")
+
+
+dataframe_creation_dispatch = DXCreationDispatch(
     module_name="dataframe",
     default="pandas",
     entrypoint_class=DataFrameBackendEntrypoint,
-    entrypoint_root="dask_expr",  # Differs from `dask.dataframe`
     name="dataframe_creation_dispatch",
 )
 
@@ -35,3 +55,41 @@ class PandasBackendEntrypoint(DataFrameBackendEntrypoint):
 
 
 dataframe_creation_dispatch.register_backend("pandas", PandasBackendEntrypoint())
+
+
+@get_collection_type.register(pd.Series)
+def get_collection_type_series(_):
+    from dask_expr._collection import Series
+
+    return Series
+
+
+@get_collection_type.register(pd.DataFrame)
+def get_collection_type_dataframe(_):
+    from dask_expr._collection import DataFrame
+
+    return DataFrame
+
+
+@get_collection_type.register(pd.Index)
+def get_collection_type_index(_):
+    from dask_expr._collection import Index
+
+    return Index
+
+
+@get_collection_type.register(object)
+def get_collection_type_object(_):
+    from dask_expr._collection import Scalar
+
+    return Scalar
+
+
+######################################
+# cuDF: Pandas Dataframes on the GPU #
+######################################
+
+
+@get_collection_type.register_lazy("cudf")
+def _register_cudf():
+    import dask_cudf  # noqa: F401

--- a/dask_expr/_backends.py
+++ b/dask_expr/_backends.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pandas as pd
+from dask.backends import CreationDispatch, detect_entrypoints
+from dask.dataframe.backends import DataFrameBackendEntrypoint
+
+
+class DaskExprCreationDispatch(CreationDispatch):
+    """Dask-Expr version of CreationDispatch
+
+    TODO: This code can all go away if CreationDispatch
+    makes it possible to override the entrypoint path.
+    We just want to allow external libraries to expose
+    a dask-expr entrypoint and dask (legacy) entrypoint
+    at the same time.
+    """
+
+    def detect_entrypoints(self):
+        return detect_entrypoints(f"dask-expr.{self._module_name}.backends")
+
+    def dispatch(self, backend: str):
+        """Return the desired backend entrypoint"""
+        try:
+            impl = self._lookup[backend]
+        except KeyError:
+            # Check entrypoints for the specified backend
+            entrypoints = self.detect_entrypoints()
+            if backend in entrypoints:
+                return self.register_backend(backend, entrypoints[backend].load()())
+        else:
+            return impl
+        raise ValueError(f"No backend dispatch registered for {backend}")
+
+
+dataframe_creation_dispatch = DaskExprCreationDispatch(
+    module_name="dataframe",
+    default="pandas",
+    entrypoint_class=DataFrameBackendEntrypoint,
+    name="dataframe_creation_dispatch",
+)
+
+
+class PandasBackendEntrypoint(DataFrameBackendEntrypoint):
+    """Pandas-Backend Entrypoint Class for Dask-Expressions
+
+    Note that all DataFrame-creation functions are defined
+    and registered 'in-place'.
+    """
+
+    @classmethod
+    def to_backend_dispatch(cls):
+        from dask.dataframe.dispatch import to_pandas_dispatch
+
+        return to_pandas_dispatch
+
+    @classmethod
+    def to_backend(cls, data, **kwargs):
+        if isinstance(data._meta, (pd.DataFrame, pd.Series, pd.Index)):
+            # Already a pandas-backed collection
+            return data
+        return data.map_partitions(cls.to_backend_dispatch(), **kwargs)
+
+
+dataframe_creation_dispatch.register_backend("pandas", PandasBackendEntrypoint())

--- a/dask_expr/_backends.py
+++ b/dask_expr/_backends.py
@@ -6,28 +6,10 @@ from dask.dataframe.backends import DataFrameBackendEntrypoint
 
 from dask_expr._dispatch import get_collection_type
 
-
-class DXCreationDispatch(CreationDispatch):
-    """Dask-expressions version of CreationDispatch"""
-
-    # TODO Remove after https://github.com/dask/dask/pull/10794
-    def dispatch(self, backend: str):
-        from dask.backends import detect_entrypoints
-
-        try:
-            impl = self._lookup[backend]
-        except KeyError:
-            entrypoints = detect_entrypoints(f"dask_expr.{self._module_name}.backends")
-            if backend in entrypoints:
-                return self.register_backend(backend, entrypoints[backend].load()())
-        else:
-            return impl
-        raise ValueError(f"No backend dispatch registered for {backend}")
-
-
-dataframe_creation_dispatch = DXCreationDispatch(
+dataframe_creation_dispatch = CreationDispatch(
     module_name="dataframe",
     default="pandas",
+    entrypoint_root="dask_expr",
     entrypoint_class=DataFrameBackendEntrypoint,
     name="dataframe_creation_dispatch",
 )

--- a/dask_expr/_backends.py
+++ b/dask_expr/_backends.py
@@ -17,7 +17,7 @@ class DXCreationDispatch(CreationDispatch):
         try:
             impl = self._lookup[backend]
         except KeyError:
-            entrypoints = detect_entrypoints(f"dask-expr.{self._module_name}.backends")
+            entrypoints = detect_entrypoints(f"dask_expr.{self._module_name}.backends")
             if backend in entrypoints:
                 return self.register_backend(backend, entrypoints[backend].load()())
         else:

--- a/dask_expr/_backends.py
+++ b/dask_expr/_backends.py
@@ -28,7 +28,6 @@ class DXCreationDispatch(CreationDispatch):
 dataframe_creation_dispatch = DXCreationDispatch(
     module_name="dataframe",
     default="pandas",
-    entrypoint_root="dask_expr",
     entrypoint_class=DataFrameBackendEntrypoint,
     name="dataframe_creation_dispatch",
 )

--- a/dask_expr/_backends.py
+++ b/dask_expr/_backends.py
@@ -8,7 +8,7 @@ dataframe_creation_dispatch = CreationDispatch(
     module_name="dataframe",
     default="pandas",
     entrypoint_class=DataFrameBackendEntrypoint,
-    entrypoint_root="dask-expr",  # Differs from `dask.dataframe`
+    entrypoint_root="dask_expr",  # Differs from `dask.dataframe`
     name="dataframe_creation_dispatch",
 )
 

--- a/dask_expr/_backends.py
+++ b/dask_expr/_backends.py
@@ -1,41 +1,14 @@
 from __future__ import annotations
 
 import pandas as pd
-from dask.backends import CreationDispatch, detect_entrypoints
+from dask.backends import CreationDispatch
 from dask.dataframe.backends import DataFrameBackendEntrypoint
 
-
-class DaskExprCreationDispatch(CreationDispatch):
-    """Dask-Expr version of CreationDispatch
-
-    TODO: This code can all go away if CreationDispatch
-    makes it possible to override the entrypoint path.
-    We just want to allow external libraries to expose
-    a dask-expr entrypoint and dask (legacy) entrypoint
-    at the same time.
-    """
-
-    def detect_entrypoints(self):
-        return detect_entrypoints(f"dask-expr.{self._module_name}.backends")
-
-    def dispatch(self, backend: str):
-        """Return the desired backend entrypoint"""
-        try:
-            impl = self._lookup[backend]
-        except KeyError:
-            # Check entrypoints for the specified backend
-            entrypoints = self.detect_entrypoints()
-            if backend in entrypoints:
-                return self.register_backend(backend, entrypoints[backend].load()())
-        else:
-            return impl
-        raise ValueError(f"No backend dispatch registered for {backend}")
-
-
-dataframe_creation_dispatch = DaskExprCreationDispatch(
+dataframe_creation_dispatch = CreationDispatch(
     module_name="dataframe",
     default="pandas",
     entrypoint_class=DataFrameBackendEntrypoint,
+    entrypoint_root="dask-expr",  # Differs from `dask.dataframe`
     name="dataframe_creation_dispatch",
 )
 

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -38,7 +38,6 @@ from dask.dataframe.utils import (
 from dask.utils import (
     IndexCallable,
     M,
-    get_default_shuffle_method,
     memory_repr,
     put_lines,
     random_state_data,
@@ -1653,19 +1652,11 @@ class DataFrame(FrameBase):
         split_every=None,
         split_out=True,
         shuffle_method=None,
-        keep=None,
+        keep="first",
     ):
         shuffle_method = _get_shuffle_preferring_order(shuffle_method)
         if keep is False:
             raise NotImplementedError("drop_duplicates with keep=False")
-        if keep is not None and get_default_shuffle_method() == "p2p":
-            warnings.warn(
-                "P2P shuffle doesn't have ordering guarantees, so keep='first' and "
-                "keep='last' might return unexpected results",
-                UserWarning,
-            )
-        elif keep is None:
-            keep = "first"
         # Fail early if subset is not valid, e.g. missing columns
         subset = _convert_to_list(subset)
         meta_nonempty(self._meta).drop_duplicates(subset=subset, keep=keep)
@@ -2333,19 +2324,11 @@ class Series(FrameBase):
         split_every=None,
         split_out=True,
         shuffle_method=None,
-        keep=None,
+        keep="first",
     ):
         shuffle_method = _get_shuffle_preferring_order(shuffle_method)
         if keep is False:
             raise NotImplementedError("drop_duplicates with keep=False")
-        if keep is not None and shuffle_method == "p2p":
-            warnings.warn(
-                "P2P shuffle doesn't have ordering guarantees, so keep='first' and "
-                "keep='last' might return unexpected results",
-                UserWarning,
-            )
-        elif keep is None:
-            keep = "first"
         return new_collection(
             DropDuplicates(
                 self,

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -55,6 +55,7 @@ from tlz import first
 
 from dask_expr import _expr as expr
 from dask_expr._align import AlignPartitions
+from dask_expr._backends import dataframe_creation_dispatch
 from dask_expr._categorical import CategoricalAccessor, Categorize, GetCategories
 from dask_expr._concat import Concat
 from dask_expr._datetime import DatetimeAccessor
@@ -1275,7 +1276,7 @@ class FrameBase(DaskMethodsMixin):
         -------
         DataFrame, Series or Index
         """
-        from dask.dataframe.backends import dataframe_creation_dispatch
+        from dask_expr._backends import dataframe_creation_dispatch
 
         # Get desired backend
         backend = backend or dataframe_creation_dispatch.backend
@@ -2710,6 +2711,7 @@ def from_graph(*args, **kwargs):
     return new_collection(FromGraph(*args, **kwargs))
 
 
+@dataframe_creation_dispatch.register_inplace("pandas")
 def from_dict(
     data,
     npartitions,
@@ -2786,6 +2788,7 @@ def from_dask_array(x, columns=None, index=None, meta=None):
     return from_dask_dataframe(df, optimize=True)
 
 
+@dataframe_creation_dispatch.register_inplace("pandas")
 def read_csv(
     path,
     *args,
@@ -2836,6 +2839,7 @@ def read_table(
     )
 
 
+@dataframe_creation_dispatch.register_inplace("pandas")
 def read_parquet(
     path=None,
     columns=None,

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -3102,6 +3102,8 @@ class Scalar(FrameBase):
 
 def new_collection(expr):
     """Create new collection from an expr"""
+    # Make sure "pandas" backend is imported
+    import dask_expr._backends  # noqa: F401
     from dask_expr._dispatch import get_collection_type
 
     meta = expr._meta

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -1275,9 +1275,14 @@ class FrameBase(DaskMethodsMixin):
         -------
         DataFrame, Series or Index
         """
-        from dask.dataframe.io import to_backend
+        from dask.dataframe.backends import dataframe_creation_dispatch
 
-        return to_backend(self.to_dask_dataframe(), backend=backend, **kwargs)
+        # Get desired backend
+        backend = backend or dataframe_creation_dispatch.backend
+        # Check that "backend" has a registered entrypoint
+        backend_entrypoint = dataframe_creation_dispatch.dispatch(backend)
+        # Call `DataFrameBackendEntrypoint.to_backend`
+        return backend_entrypoint.to_backend(self, **kwargs)
 
     def dot(self, other, meta=no_default):
         if not isinstance(other, FrameBase):

--- a/dask_expr/_dispatch.py
+++ b/dask_expr/_dispatch.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from dask.utils import Dispatch
+
+get_collection_type = Dispatch("get_collection_type")

--- a/dask_expr/tests/test_distributed.py
+++ b/dask_expr/tests/test_distributed.py
@@ -335,17 +335,3 @@ def test_merge_combine_similar_squash_merges(add_repartition):
         out.reset_index(drop=True),
         expected,
     )
-
-
-@gen_cluster(client=True)
-async def test_p2p_drop_duplicates(c, s, a, b):
-    df = dx.datasets.timeseries(
-        start="2000-01-01",
-        end="2000-01-10",
-        dtypes={"x": float, "y": float},
-        freq="10 s",
-    )
-    with pytest.warns(UserWarning, match="keep"):
-        df.drop_duplicates(keep="first")
-    with pytest.warns(UserWarning, match="keep"):
-        df.x.drop_duplicates(keep="first")


### PR DESCRIPTION
It seems like we will temporarily need to allow external libraries (i.e. cudf) to register a `DaskBackendEntrypoint` for both `dask.dataframe` and `dask_expr`. I think the easiest approach is to let cudf use a `"dask-expr.dataframe.backend"` entrypoint path for dask-expr (and continue using `"dask.dataframe.backend"` in the legacy `dask.dataframe` API).

This PR also introduces a simple `get_collection_type` dispatch function (the dask-expr version of `get_parallel_type`). This completely breaks cudf support for now, but dask-expr + cudf is already broken, and this is probably the only way to **fix** it anyway.

NOTE: This PR does not introduce any *new* dispatching mechanisms (like https://github.com/dask-contrib/dask-expr/pull/321). It just adds enough code to support the existing dispatching mechanisms used in `dask.dataframe`.