### PR TITLE
add test that shows how lambda tokenization is broken

### DIFF
--- a/dask_expr/tests/test_util.py
+++ b/dask_expr/tests/test_util.py
@@ -1,6 +1,43 @@
+import pickle
+
 import pytest
 
-from dask_expr._util import RaiseAttributeError
+from dask_expr._util import RaiseAttributeError, _tokenize_deterministic
+
+
+def _clear_function_cache():
+    from dask.base import function_cache, function_cache_lock
+
+    with function_cache_lock:
+        function_cache.clear()
+
+
+def tokenize(x, /, __ensure_deterministic=True, *args, **kwargs):
+    _clear_function_cache()
+    try:
+        before = _tokenize_deterministic(x, *args, **kwargs)
+        _clear_function_cache()
+        if __ensure_deterministic:
+            assert before == _tokenize_deterministic(x, *args, **kwargs)
+            _clear_function_cache()
+        try:
+            after = _tokenize_deterministic(
+                pickle.loads(pickle.dumps(x)), *args, **kwargs
+            )
+        except (AttributeError, pickle.PicklingError):
+            # If we go down this path we're almost certainly guaranteed to fail
+            # since cloudpickle dumps are not deterministic and the tokenization
+            # is relying on that
+            import cloudpickle
+
+            after = _tokenize_deterministic(
+                cloudpickle.loads(cloudpickle.dumps(x)), *args, **kwargs
+            )
+
+        assert before == after
+        return before
+    finally:
+        _clear_function_cache()
 
 
 def test_raises_attribute_error():
@@ -19,3 +56,36 @@ def test_raises_attribute_error():
         B.x
     with pytest.raises(AttributeError, match="'B' object has no attribute 'x'"):
         B().x
+
+
+def test_tokenize_lambda():
+    func = lambda x: x + 1
+    tokenize(func)
+
+
+import pandas as pd
+
+from dask_expr import from_pandas
+
+
+def test_tokenize_deterministic():
+    ddf = from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    tokenize(ddf)
+
+    def identity(x):
+        return x
+
+    ddf2 = ddf.map_partitions(identity)
+    tokenize(ddf2)
+
+    def identity(x):
+        return x + 1
+
+    ddf3 = ddf.map_partitions(identity)
+
+    from distributed.protocol.pickle import dumps, loads
+
+    assert loads(dumps(ddf))._name == ddf._name
+
+    assert loads(dumps(ddf2))._name == ddf2._name
+    assert tokenize(ddf2) != tokenize(ddf3)

--- a/dask_expr/tests/test_util.py
+++ b/dask_expr/tests/test_util.py
@@ -70,13 +70,16 @@ from dask_expr import from_pandas
 
 def test_tokenize_deterministic():
     ddf = from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
-    tokenize(ddf)
+    assert ddf._name == ddf._name
+    # This fails without https://github.com/dask/dask/pull/10808 already
+    # tokenize(ddf)
 
     def identity(x):
         return x
 
     ddf2 = ddf.map_partitions(identity)
-    tokenize(ddf2)
+    # This fails without https://github.com/dask/dask/pull/10808 already
+    # tokenize(ddf2)
 
     def identity(x):
         return x + 1
@@ -85,7 +88,10 @@ def test_tokenize_deterministic():
 
     from distributed.protocol.pickle import dumps, loads
 
+    # This works since ddf is rather trivial and tokenization for from_pandas is
+    # actually properly implemented
     assert loads(dumps(ddf))._name == ddf._name
 
+    # This fails since the lambda is not deterministic
     assert loads(dumps(ddf2))._name == ddf2._name
     assert tokenize(ddf2) != tokenize(ddf3)

--- a/dask_expr/tests/test_util.py
+++ b/dask_expr/tests/test_util.py
@@ -71,14 +71,18 @@ from dask_expr import from_pandas
 def test_tokenize_deterministic():
     ddf = from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
     assert ddf._name == ddf._name
-    # This fails without https://github.com/dask/dask/pull/10808 already
+    tokenize(ddf._expr)
+    # This fails because there is no tokenization registered for our collection
+    # Works with https://github.com/dask/dask/pull/10808
     # tokenize(ddf)
 
     def identity(x):
         return x
 
     ddf2 = ddf.map_partitions(identity)
-    # This fails without https://github.com/dask/dask/pull/10808 already
+    # Fails because of local functions
+
+    tokenize(ddf2._expr)
     # tokenize(ddf2)
 
     def identity(x):
@@ -94,4 +98,4 @@ def test_tokenize_deterministic():
 
     # This fails since the lambda is not deterministic
     assert loads(dumps(ddf2))._name == ddf2._name
-    assert tokenize(ddf2) != tokenize(ddf3)
+    assert tokenize(ddf2._expr) != tokenize(ddf3._expr)


### PR DESCRIPTION
https://github.com/dask-contrib/dask-expr/pull/223 had good intention and introduced a utility function `_tokenize_deterministic` that is setting the `tokenize.ensure-deterministic` flag such that we can ensure that the tokens we're generating are indeed deterministic. 
Determinism in this context is mildly ambiguous and there are subtly different consistency guarantees we need if we want to pickle `Expr` objects in a way that is deterministic across python processes/interpreters

Essentially everything we'd need to fall back to cloudpickle to serialize is also susceptible to not being deterministically tokenized (therefore this loosely relates to https://github.com/dask-contrib/dask-expr/pull/331#discussion_r1357189975 even though those are separate issues) since the tokenization is using cloudpickle behind the scenes for those cases. In way that defeats the entire purpose of the tokenization engine (see point 3. below).

https://github.com/dask-contrib/dask-expr/pull/223 also implemented a "fix" for `LambdaType` functions which is using the `str` representation of those functions which looks like `<function func.<locals>.<lambda> at 0x107363be0>`. This is unique inside of an interpreter session since it includes the memory address where the lambda is stored but this changes once moved to another interpreter.

This effectively hard blocks https://github.com/dask-contrib/dask-expr/issues/14

There are a couple of options (I'm not really happy about either but here we go...)

1. Enforce pickle as a serialization protocol and forbid usage of local functions, types, etc. (effectively https://github.com/dask-contrib/dask-expr/pull/331 but this would expand to all user APIs. We could wrap user defined objects with some magical class but this would feel a little awkward I think)
1. A slightly better/milder version of 1). I believe we can define deterministic cross-interpreter tokens for lambdas/local functions. I had something like this in a version of https://github.com/dask/dask/pull/10808 but it turned out to not be python version stable so I ended up removing it again. I'd have to run a couple 
1. Abandon tokenization entirely. Inside of an interpreter this problem is easy since if an object doesn't implement a `__hash__` we could just use it's `id` for a unique identifier and hash (or just stick with the current engine although it feels slightly over engineered then). From what I understand the entire tokenization is merely for the distributed scheduler but I see a way how to avoid that. This would require us to rewrite how client and scheduler are communicating in `dask/distributed` but I believe this is doable with a reasonable amount of effort. The scheduler would de-facto be the source of truth and be responsible for key generation and not the other way round. Locally generated keys would no longer map to remote keys. That would be fine, I guess?


cc @rjzamora @mrocklin @phofl 


Note: This problem has been around forever. HLGs were not as much affected by this since their names are actually not unique (e.g. https://github.com/dask/dask/issues/9888). `Expr` are calculating names/tokens recursively which is objectively much better for key uniqueness but also means that if there is any object inside of the expr-tree that cannot be tokenized deterministically, this affects the entire tree.