### PR TITLE
Remove ``Expr._required_attribute``

### DIFF
--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -857,19 +857,19 @@ class IdxMin(Reduction):
     reduction_chunk = idxmaxmin_chunk
     reduction_combine = idxmaxmin_combine
     reduction_aggregate = idxmaxmin_agg
-    _required_attribute = "idxmin"
+    _reduction_attribute = "idxmin"
 
     @property
     def chunk_kwargs(self):
         return dict(
             skipna=self.skipna,
-            fn=self._required_attribute,
+            fn=self._reduction_attribute,
             numeric_only=self.numeric_only,
         )
 
     @property
     def combine_kwargs(self):
-        return dict(skipna=self.skipna, fn=self._required_attribute)
+        return dict(skipna=self.skipna, fn=self._reduction_attribute)
 
     @property
     def aggregate_kwargs(self):
@@ -877,7 +877,7 @@ class IdxMin(Reduction):
 
 
 class IdxMax(IdxMin):
-    _required_attribute = "idxmax"
+    _reduction_attribute = "idxmax"
 
 
 class Cov(Reduction):
@@ -961,7 +961,6 @@ class Size(Reduction):
 class NBytes(Reduction):
     # Only supported for Series objects
     reduction_aggregate = sum
-    _required_attribute = "nbytes"
 
     @staticmethod
     def reduction_chunk(ser):


### PR DESCRIPTION
The `_required_attribute` check was meant to avoid infinite `AttributeError` recursion. However, we can also avoid this recursion by expanding the current "_meta" check in `Expr.__getattr__` to throw a `RuntimeError` when the key is anything that starts with `"_meta"` (e.g. "_meta_chunk").

This PR also consolidates the redundant `dask_expr._expr.Expr.__getattr__` and `dask_expr._core.Expr.__getattr__` logic in once place. However, I can revert that change if there were two nearly-identical definitions for a reason.