### PR TITLE
Fix `test_repartition_quantiles` to unblock CI

### DIFF
--- a/dask_expr/tests/test_quantiles.py
+++ b/dask_expr/tests/test_quantiles.py
@@ -1,3 +1,5 @@
+from numpy import allclose
+
 from dask_expr import from_pandas
 from dask_expr.tests._util import _backend_library, assert_eq
 
@@ -12,7 +14,9 @@ def test_repartition_quantiles():
     expected = pd.Series(
         [1, 1, 3, 7, 9, 15], index=[0, 0.2, 0.4, 0.6, 0.8, 1], name="a"
     )
-    assert_eq(result, expected)
+    # Set `check_exact=False` explicitly
+    # See: https://github.com/dask-contrib/dask-expr/issues/801
+    assert_eq(result, expected, check_exact=False)
 
     result = df.a._repartition_quantiles(npartitions=4)
     expected = pd.Series([1, 2, 5, 8, 15], index=[0, 0.25, 0.5, 0.75, 1], name="a")

--- a/dask_expr/tests/test_quantiles.py
+++ b/dask_expr/tests/test_quantiles.py
@@ -1,5 +1,3 @@
-from numpy import allclose
-
 from dask_expr import from_pandas
 from dask_expr.tests._util import _backend_library, assert_eq
 
@@ -14,7 +12,7 @@ def test_repartition_quantiles():
     expected = pd.Series(
         [1, 1, 3, 7, 9, 15], index=[0, 0.2, 0.4, 0.6, 0.8, 1], name="a"
     )
-    # Set `check_exact=False` explicitly
+    # Set `check_exact=False`
     # See: https://github.com/dask-contrib/dask-expr/issues/801
     assert_eq(result, expected, check_exact=False)
 


### PR DESCRIPTION
Pandas 2.2 changed the default for `check_exact` in `assert_frame_equal`. This PR sets it to `check_exact=False` to revert to the original behavior.

Closes https://github.com/dask-contrib/dask-expr/issues/801