### PR TITLE
pandas 2.2: fix test_repartition_quantiles

### DIFF
--- a/dask_expr/tests/test_quantiles.py
+++ b/dask_expr/tests/test_quantiles.py
@@ -12,8 +12,8 @@ def test_repartition_quantiles():
     expected = pd.Series(
         [1, 1, 3, 7, 9, 15], index=[0, 0.2, 0.4, 0.6, 0.8, 1], name="a"
     )
-    assert_eq(result, expected)
+    assert_eq(result, expected, check_exact=False)
 
     result = df.a._repartition_quantiles(npartitions=4)
     expected = pd.Series([1, 2, 5, 8, 15], index=[0, 0.25, 0.5, 0.75, 1], name="a")
-    assert_eq(result, expected)
+    assert_eq(result, expected, check_exact=False)


### PR DESCRIPTION
- Closes #801
- Supersedes #802
- Upstream: https://github.com/pandas-dev/pandas/issues/57067