### PR TITLE
Split out dask/dask tests in CI

### DIFF
--- a/.github/workflows/dask_test.yaml
+++ b/.github/workflows/dask_test.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.12"]
         environment-file: [ci/environment.yml]
 
     steps:

--- a/.github/workflows/dask_test.yaml
+++ b/.github/workflows/dask_test.yaml
@@ -1,4 +1,4 @@
-name: Tests
+name: dask/dask tests
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch
 concurrency:
-  group: test-${{ github.ref }}
+  group: dask_test-${{ github.ref }}
   cancel-in-progress: true
 
 # Required shell entrypoint to have properly activated conda environments
@@ -53,8 +53,5 @@ jobs:
         # Output of `micromamba list` is buggy for pip-installed packages
         run: pip list | grep -E 'dask|distributed'
 
-      - name: Run tests
-        run: py.test -n auto --verbose --cov=dask_expr --cov-report=xml
-
-      - name: Coverage
-        uses: codecov/codecov-action@v3
+      - name: Run Dask DataFrame tests
+        run: python -c "import dask.dataframe as dd; dd.test_dataframe()"

--- a/.github/workflows/dask_test.yaml
+++ b/.github/workflows/dask_test.yaml
@@ -1,4 +1,4 @@
-name: dask/dask tests
+name: Tests / dask/dask
 
 on:
   push:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,8 +11,8 @@ jobs:
     name: pre-commit hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
The dask/dask tests never got to run if there's a failure in the dask-expr tests.
This PR also reduces end-to-end runtime by 3 minutes.