### PR TITLE
Revert "Pin `pytest<8.0.0` (#813)"

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,7 +2,7 @@ name: dask-expr
 channels:
   - conda-forge
 dependencies:
-  - pytest<8.0.0
+  - pytest
   - pytest-cov
   - pytest-xdist
   - dask  # overridden by git tip below


### PR DESCRIPTION
- Closes #814
- Fixed by dask/dask#10868
