### PR TITLE
Always allow multiple values in `ascending` for `sort_values`

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -2281,18 +2281,8 @@ class DataFrame(FrameBase):
                 "You passed %s" % str(by)
             )
 
-        if not isinstance(ascending, bool):
-            # support [True] as input
-            if (
-                isinstance(ascending, list)
-                and len(ascending) == 1
-                and isinstance(ascending[0], bool)
-            ):
-                ascending = ascending[0]
-            elif self.npartitions > 1:
-                raise NotImplementedError(
-                    f"Dask currently only supports a single boolean for ascending. You passed {str(ascending)}"
-                )
+        if not isinstance(ascending, bool) and not len(ascending) == len(by):
+            raise ValueError(f"Length of {ascending=} != length of {by=}")
 
         return new_collection(
             SortValues(

--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -1000,9 +1000,8 @@ class SortValues(BaseSetIndexSortValues):
 
         partitions = _SetPartitionsPreSetIndex(
             _divisions_by,
-            _divisions_by._meta._constructor(divisions).sort_values(
-                ascending=self._divisions_ascending
-            ),
+            _divisions_by._meta._constructor(divisions).sort_values(),
+            ascending=self._divisions_ascending,
         )
         assigned = Assign(self.frame, "_partitions", partitions)
         shuffled = Shuffle(

--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -935,12 +935,20 @@ class SortValues(BaseSetIndexSortValues):
             self.frame,
             self.frame[self.by[0]],
             self._npartitions_input,
-            self.ascending,
+            self._divisions_ascending,
             upsample=self.upsample,
         )
         if presorted:
             return self.frame.divisions
         return (None,) * len(divisions)
+
+    @property
+    def _divisions_ascending(self) -> bool:
+        divisions_ascending = self.ascending
+        if not isinstance(divisions_ascending, bool):
+            divisions_ascending = divisions_ascending[0]
+        assert isinstance(divisions_ascending, bool)
+        return divisions_ascending
 
     @property
     def sort_function(self):
@@ -977,12 +985,12 @@ class SortValues(BaseSetIndexSortValues):
                 self.frame, self.sort_function, self.sort_function_kwargs
             )
 
-        by = self.frame[self.by[0]]
+        _divisions_by = self.frame[self.by[0]]
         divisions, _, _, presorted = _get_divisions(
             self.frame,
-            by,
+            _divisions_by,
             self._npartitions_input,
-            self.ascending,
+            self._divisions_ascending,
             upsample=self.upsample,
         )
         if presorted and self.npartitions == self.frame.npartitions:
@@ -991,7 +999,10 @@ class SortValues(BaseSetIndexSortValues):
             )
 
         partitions = _SetPartitionsPreSetIndex(
-            by, by._meta._constructor(divisions).sort_values(ascending=self.ascending)
+            _divisions_by,
+            _divisions_by._meta._constructor(divisions).sort_values(
+                ascending=self._divisions_ascending
+            ),
         )
         assigned = Assign(self.frame, "_partitions", partitions)
         shuffled = Shuffle(
@@ -1010,25 +1021,36 @@ class SortValues(BaseSetIndexSortValues):
     def _simplify_up(self, parent, dependents):
         from dask_expr._expr import Filter, Head, Tail
 
-        if self.frame.npartitions > 1 and isinstance(parent, Head):
-            if self.ascending:
+        _all_ascending = (
+            self.ascending
+            if isinstance(self.ascending, bool)
+            else all(ascending for ascending in self.ascending)
+        )
+        _all_descending = (
+            not self.ascending
+            if isinstance(self.ascending, bool)
+            else all(not ascending for ascending in self.ascending)
+        )
+
+        if isinstance(parent, Head):
+            if _all_ascending:
                 if is_valid_nth_dtype(self._meta_by_dtype):
                     return NSmallest(self.frame, n=parent.n, _columns=self.by)
                 else:
                     return NSmallestSlow(self.frame, n=parent.n, _columns=self.by)
-            else:
+            elif _all_descending:
                 if is_valid_nth_dtype(self._meta_by_dtype):
                     return NLargest(self.frame, n=parent.n, _columns=self.by)
                 else:
                     return NLargestSlow(self.frame, n=parent.n, _columns=self.by)
 
-        if self.frame.npartitions > 1 and isinstance(parent, Tail):
-            if self.ascending:
+        if isinstance(parent, Tail):
+            if _all_ascending:
                 if is_valid_nth_dtype(self._meta_by_dtype):
                     return NLargest(self.frame, n=parent.n, _columns=self.by)
                 else:
                     return NLargestSlow(self.frame, n=parent.n, _columns=self.by)
-            else:
+            elif _all_descending:
                 if is_valid_nth_dtype(self._meta_by_dtype):
                     return NSmallest(self.frame, n=parent.n, _columns=self.by)
                 else:

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -444,8 +444,9 @@ def test_sort_tail_nsmallest(df, pdf):
     assert a.optimize()._name == b.optimize()._name
 
 
-def test_sort_values_conflicting_ascending_head_tail(pdf):
-    df = from_pandas(pdf, npartitions=1)
+@pytest.mark.parametrize("npartitions", [1, 3])
+def test_sort_values_conflicting_ascending_head_tail(pdf, npartitions):
+    df = from_pandas(pdf, npartitions=npartitions)
     assert_eq(
         df.sort_values(by=["x", "y"], ascending=[True, False]).head(10),
         pdf.sort_values(by=["x", "y"], ascending=[True, False]).head(10),
@@ -460,6 +461,7 @@ def test_sort_values_conflicting_ascending_head_tail(pdf):
         df.sort_values(by=["x", "y"], ascending=[True, False]).tail(10),
         pdf.sort_values(by=["x", "y"], ascending=[True, False]).tail(10),
     )
+
     assert_eq(
         df.sort_values(by=["x", "y"], ascending=[False, True]).tail(10),
         pdf.sort_values(by=["x", "y"], ascending=[False, True]).tail(10),

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -316,8 +316,10 @@ def test_sort_values(df, pdf, shuffle):
         df.sort_values("x", shuffle_method=shuffle, upsample=2.0), pdf.sort_values("x")
     )
 
-    with pytest.raises(NotImplementedError, match="a single boolean for ascending"):
-        df.sort_values(by=["x", "y"], shuffle_method=shuffle, ascending=[True, True])
+    assert_eq(
+        df.sort_values(by=["x", "y"], shuffle_method=shuffle, ascending=[True, True]),
+        pdf.sort_values(by=["x", "y"], ascending=[True, True]),
+    )
     with pytest.raises(NotImplementedError, match="sorting by named columns"):
         df.sort_values(by=1, shuffle_method=shuffle)
 
@@ -388,64 +390,17 @@ def test_sort_head_nlargest(df, pdf):
     b = df.nsmallest(10, columns=["x"]).expr
     assert a.optimize()._name == b.optimize()._name
 
-    a = df.sort_values(["x", "y"], ascending=[False]).head(10, compute=False).expr
+    a = (
+        df.sort_values(["x", "y"], ascending=[False, False])
+        .head(10, compute=False)
+        .expr
+    )
     b = df.nlargest(10, columns=["x", "y"]).expr
     assert a.optimize()._name == b.optimize()._name
 
-    a = df.sort_values(["x", "y"], ascending=[True]).head(10, compute=False).expr
+    a = df.sort_values(["x", "y"], ascending=[True, True]).head(10, compute=False).expr
     b = df.nsmallest(10, columns=["x", "y"]).expr
     assert a.optimize()._name == b.optimize()._name
-
-    with pytest.raises(
-        NotImplementedError,
-        match="Dask currently only supports a single boolean for ascending",
-    ):
-        a = (
-            df.sort_values(["x", "y"], ascending=[False, True])
-            .head(10, compute=False)
-            .expr
-        )
-
-
-def test_sort_single_partition_head_nlargest():
-    pdf = pd.DataFrame({"x": np.random.random(100), "y": np.random.random(100)})
-    df = from_pandas(pdf, npartitions=1)
-
-    result = df.sort_values("x", ascending=False).head(10)
-    expected = pdf.sort_values("x", ascending=False).head(10)
-    assert_eq(result, expected, sort_results=False)
-
-    result = df.sort_values("x", ascending=True).head(10)
-    expected = pdf.sort_values("x", ascending=True).head(10)
-    assert_eq(result, expected, sort_results=False)
-
-    result = df.sort_values("x", ascending=[False]).head(10)
-    expected = pdf.sort_values("x", ascending=[False]).head(10)
-    assert_eq(result, expected, sort_results=False)
-
-    result = df.sort_values("x", ascending=[True]).head(10)
-    expected = pdf.sort_values("x", ascending=[True]).head(10)
-    assert_eq(result, expected, sort_results=False)
-
-    result = df.sort_values(["x"], ascending=[True]).head(10)
-    expected = pdf.sort_values(["x"], ascending=[True]).head(10)
-    assert_eq(result, expected, sort_results=False)
-
-    result = df.sort_values(["x"], ascending=[False]).head(10)
-    expected = pdf.sort_values(["x"], ascending=[False]).head(10)
-    assert_eq(result, expected, sort_results=False)
-
-    result = df.sort_values(["x", "y"], ascending=[False]).head(10)
-    expected = pdf.sort_values(["x", "y"], ascending=False).head(10)
-    assert_eq(result, expected, sort_results=False)
-
-    result = df.sort_values(["x", "y"], ascending=[True]).head(10)
-    expected = pdf.sort_values(["x", "y"], ascending=True).head(10)
-    assert_eq(result, expected, sort_results=False)
-
-    result = df.sort_values(["x", "y"], ascending=[False, True]).head(10)
-    expected = pdf.sort_values(["x", "y"], ascending=[False, True]).head(10)
-    assert_eq(result, expected, sort_results=False)
 
 
 def test_sort_tail_nsmallest(df, pdf):
@@ -473,64 +428,41 @@ def test_sort_tail_nsmallest(df, pdf):
     b = df.nlargest(10, columns=["x"]).expr
     assert a.optimize()._name == b.optimize()._name
 
-    a = df.sort_values(["x", "y"], ascending=[False]).tail(10, compute=False).expr
-    b = df.nsmallest(10, columns=["x", "y"]).expr
-    assert a.optimize()._name == b.optimize()._name
+    with pytest.raises(ValueError, match="Length of ascending"):
+        df.sort_values(["x", "y"], ascending=[False]).tail(10, compute=False)
 
-    a = df.sort_values(["x", "y"], ascending=[True]).tail(10, compute=False).expr
+    a = df.sort_values(["x", "y"], ascending=[True, True]).tail(10, compute=False).expr
     b = df.nlargest(10, columns=["x", "y"]).expr
     assert a.optimize()._name == b.optimize()._name
 
-    with pytest.raises(
-        NotImplementedError,
-        match="Dask currently only supports a single boolean for ascending",
-    ):
-        a = (
-            df.sort_values(["x", "y"], ascending=[False, True])
-            .head(10, compute=False)
-            .expr
-        )
+    a = (
+        df.sort_values(["x", "y"], ascending=[False, False])
+        .tail(10, compute=False)
+        .expr
+    )
+    b = df.nsmallest(10, columns=["x", "y"]).expr
+    assert a.optimize()._name == b.optimize()._name
 
 
-def test_sort_single_partition_tail():
-    pdf = pd.DataFrame({"x": np.random.random(100), "y": np.random.random(100)})
-    df = from_pandas(pdf, npartitions=1)
+def test_sort_values_conflicting_ascending_head_tail(df, pdf):
+    assert_eq(
+        df.sort_values(by=["x", "y"], ascending=[True, False]).head(10),
+        pdf.sort_values(by=["x", "y"], ascending=[True, False]).head(10),
+    )
 
-    result = df.sort_values("x", ascending=False).tail(10)
-    expected = pdf.sort_values("x", ascending=False).tail(10)
-    assert_eq(result, expected, sort_results=False)
+    assert_eq(
+        df.sort_values(by=["x", "y"], ascending=[False, True]).head(10),
+        pdf.sort_values(by=["x", "y"], ascending=[False, True]).head(10),
+    )
 
-    result = df.sort_values("x", ascending=True).tail(10)
-    expected = pdf.sort_values("x", ascending=True).tail(10)
-    assert_eq(result, expected, sort_results=False)
-
-    result = df.sort_values("x", ascending=[False]).tail(10)
-    expected = pdf.sort_values("x", ascending=[False]).tail(10)
-    assert_eq(result, expected, sort_results=False)
-
-    result = df.sort_values("x", ascending=[True]).tail(10)
-    expected = pdf.sort_values("x", ascending=[True]).tail(10)
-    assert_eq(result, expected, sort_results=False)
-
-    result = df.sort_values(["x"], ascending=[False]).tail(10)
-    expected = pdf.sort_values(["x"], ascending=[False]).tail(10)
-    assert_eq(result, expected, sort_results=False)
-
-    result = df.sort_values(["x"], ascending=[True]).tail(10)
-    expected = pdf.sort_values(["x"], ascending=[True]).tail(10)
-    assert_eq(result, expected, sort_results=False)
-
-    result = df.sort_values(["x", "y"], ascending=[False]).tail(10)
-    expected = pdf.sort_values(["x", "y"], ascending=False).tail(10)
-    assert_eq(result, expected, sort_results=False)
-
-    result = df.sort_values(["x", "y"], ascending=[True]).tail(10)
-    expected = pdf.sort_values(["x", "y"], ascending=True).tail(10)
-    assert_eq(result, expected, sort_results=False)
-
-    result = df.sort_values(["x", "y"], ascending=[False, True]).tail(10)
-    expected = pdf.sort_values(["x", "y"], ascending=[False, True]).tail(10)
-    assert_eq(result, expected, sort_results=False)
+    assert_eq(
+        df.sort_values(by=["x", "y"], ascending=[True, False]).tail(10),
+        pdf.sort_values(by=["x", "y"], ascending=[True, False]).tail(10),
+    )
+    assert_eq(
+        df.sort_values(by=["x", "y"], ascending=[False, True]).tail(10),
+        pdf.sort_values(by=["x", "y"], ascending=[False, True]).tail(10),
+    )
 
 
 @xfail_gpu("cudf udf support")

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -444,7 +444,8 @@ def test_sort_tail_nsmallest(df, pdf):
     assert a.optimize()._name == b.optimize()._name
 
 
-def test_sort_values_conflicting_ascending_head_tail(df, pdf):
+def test_sort_values_conflicting_ascending_head_tail(pdf):
+    df = from_pandas(pdf, npartitions=1)
     assert_eq(
         df.sort_values(by=["x", "y"], ascending=[True, False]).head(10),
         pdf.sort_values(by=["x", "y"], ascending=[True, False]).head(10),


### PR DESCRIPTION
Implements changes made in https://github.com/dask/dask/pull/10864