### PR TITLE
Make filter pushdown work for more complicated filters

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1850,7 +1850,11 @@ class Filter(Blockwise):
     def _simplify_up(self, parent, dependents):
         if isinstance(parent, Filter) and not isinstance(self.frame, Filter):
             if not self.frame._filter_passthrough_available(self, dependents):
-                # collect filters if we can't move them anymore
+                # We want to collect filters again when we can't move them
+                # anymore. Otherwise, a chain of Filters might nlock Projections
+                # We start with the first Filter, e.g. if my child isn't a filter
+                # anymore. Filters above that don't know if the first Filter can
+                # still move further
                 return self.frame[
                     self.predicate & parent.predicate.substitute(self, self.frame)
                 ]

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -72,6 +72,11 @@ class Expr(core.Expr):
     _is_length_preserving = False
     _filter_passthrough = False
 
+    def _filter_passthrough_available(self, parent, dependents):
+        return self._filter_passthrough and is_filter_pushdown_available(
+            self, parent, dependents
+        )
+
     @functools.cached_property
     def ndim(self):
         meta = self._meta
@@ -1181,12 +1186,9 @@ class Elemwise(Blockwise):
     _is_length_preserving = True
 
     def _simplify_up(self, parent, dependents):
-        if self._filter_passthrough and isinstance(parent, Filter):
-            if self._name != parent.frame._name:
-                # We can't push the filter through the filter condition
-                return
-            if not is_filter_pushdown_available(self, parent, dependents):
-                return
+        if isinstance(parent, Filter) and self._filter_passthrough_available(
+            parent, dependents
+        ):
             return type(self)(
                 self.frame[parent.predicate.substitute(self, self.frame)],
                 *self.operands[1:],
@@ -1846,10 +1848,14 @@ class Filter(Blockwise):
     operation = operator.getitem
 
     def _simplify_up(self, parent, dependents):
+        if isinstance(parent, Filter) and not isinstance(self.frame, Filter):
+            if not self.frame._filter_passthrough_available(self, dependents):
+                # collect filters if we can't move them anymore
+                return self.frame[
+                    self.predicate & parent.predicate.substitute(self, self.frame)
+                ]
         if isinstance(parent, Projection):
-            if self.frame._filter_passthrough and is_filter_pushdown_available(
-                self.frame, self, dependents
-            ):
+            if self.frame._filter_passthrough_available(self, dependents):
                 # We can't push Projections through filters if the preceding operation
                 # allows us to push filters further down the graph because Projections
                 # block filter pushdown

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -380,14 +380,6 @@ class Merge(Expr):
                 predicate_cols = set(predicate.columns)
             elif isinstance(predicate, Binop):
                 if isinstance(predicate, And):
-                    # if isinstance(predicate.left, And):
-                    #     predicate_first = predicate.right
-                    #     predicate_second = predicate.left
-                    # else:
-                    #     predicate_first = predicate.left
-                    #     predicate_second = predicate.right
-                    # new = Filter(self, predicate_first)
-                    # new_pred = predicate_second.substitute(self, new)
                     new = Filter(self, predicate.left)
                     new_pred = predicate.right.substitute(self, new)
                     return Filter(new, new_pred)

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -78,7 +78,17 @@ class Merge(Expr):
         "_npartitions": None,
         "broadcast": None,
     }
-    _filter_passthrough = True
+
+    @property
+    def _filter_passthrough(self):
+        raise NotImplementedError(
+            "please use _filter_passthrough_available to make this decision"
+        )
+
+    def _filter_passthrough_available(self, parent, dependents):
+        return is_filter_pushdown_available(self, parent, dependents) or isinstance(
+            parent.predicate, And
+        )
 
     def __str__(self):
         return f"Merge({self._name[-7:]})"
@@ -360,9 +370,8 @@ class Merge(Expr):
 
     def _simplify_up(self, parent, dependents):
         if isinstance(parent, Filter):
-            if not is_filter_pushdown_available(self, parent, dependents):
-                if not isinstance(parent.predicate, And):
-                    return
+            if not self._filter_passthrough_available(parent, dependents):
+                return
             new_left = self.left
             new_right = self.right
             predicate_cols = set()
@@ -371,6 +380,14 @@ class Merge(Expr):
                 predicate_cols = set(predicate.columns)
             elif isinstance(predicate, Binop):
                 if isinstance(predicate, And):
+                    # if isinstance(predicate.left, And):
+                    #     predicate_first = predicate.right
+                    #     predicate_second = predicate.left
+                    # else:
+                    #     predicate_first = predicate.left
+                    #     predicate_second = predicate.right
+                    # new = Filter(self, predicate_first)
+                    # new_pred = predicate_second.substitute(self, new)
                     new = Filter(self, predicate.left)
                     new_pred = predicate.right.substitute(self, new)
                     return Filter(new, new_pred)

--- a/dask_expr/tests/test_merge.py
+++ b/dask_expr/tests/test_merge.py
@@ -761,6 +761,16 @@ def test_filter_merge():
     assert df.simplify()._name == expected.simplify()._name
     assert_eq(df, expected)
 
+    df = a.merge(b)
+    df = df[df.d & df.z & (df.b == 1)][["a"]]
+    aa = a[a.d & (a.b == 1)]
+    bb = b[b.z]
+    expected = aa.merge(bb)[["a"]]
+    df.simplify().pprint()
+    expected.simplify().pprint()
+    assert df.simplify()._name == expected.simplify()._name
+    assert_eq(df, expected)
+
 
 def test_merge_avoid_overeager_filter_pushdown():
     df = pd.DataFrame({"a": [1, 2, 3], "b": 1})


### PR DESCRIPTION
We were making decisions differently when a filter would modify its child, this wasn't reflected in th Filter class, which in turn let Projections through even though it shouldn't. Moving this logic to a method that can be overridden solves this inconsistency


Having multiple filters after each other will block projections if we kept it the way it was. Squashing them together again when we can't move them anymore solves this nicely