### PR TITLE
Raise ``NotImplementedError`` for unsupported ``SeriesGroupBy.var/std``

### DIFF
--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -1745,7 +1745,7 @@ class GroupBy:
         ):
             if len(result.columns) < 1:
                 raise NotImplementedError(
-                    "Cannnot call `SeriesGroupBy.var` on the key column. "
+                    "Cannot call `SeriesGroupBy.var` on the key column. "
                     "Please use `aggregate` if you really need to do this."
                 )
             result = result[result.columns[0]]
@@ -1785,7 +1785,7 @@ class GroupBy:
         ):
             if len(result.columns) < 1:
                 raise NotImplementedError(
-                    "Cannnot call `SeriesGroupBy.std` on the key column. "
+                    "Cannot call `SeriesGroupBy.std` on the key column. "
                     "Please use `aggregate` if you really need to do this."
                 )
             result = result[result.columns[0]]

--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -1743,6 +1743,11 @@ class GroupBy:
             or is_scalar(self._slice)
             and self._slice is not None
         ):
+            if len(result.columns) < 1:
+                raise NotImplementedError(
+                    "Cannnot call `SeriesGroupBy.var` on the key column. "
+                    "Please use `aggregate` if you really need to do this."
+                )
             result = result[result.columns[0]]
         return result
 
@@ -1778,6 +1783,11 @@ class GroupBy:
             or is_scalar(self._slice)
             and self._slice is not None
         ):
+            if len(result.columns) < 1:
+                raise NotImplementedError(
+                    "Cannnot call `SeriesGroupBy.std` on the key column. "
+                    "Please use `aggregate` if you really need to do this."
+                )
             result = result[result.columns[0]]
         return result
 

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -907,3 +907,11 @@ def test_series_groupby_cumfunc_with_named_index(npartitions, func):
     expected = getattr(df["y"].groupby("x"), func)()
     result = getattr(ddf["y"].groupby("x"), func)()
     assert_eq(result, expected)
+
+
+@pytest.mark.parametrize("attr", ("std", "var"))
+def test_series_groupby_not_supported(df, attr):
+    # See: https://github.com/dask-contrib/dask-expr/issues/840
+    g = df.groupby("x")
+    with pytest.raises(NotImplementedError, match="Please use `aggregate`"):
+        getattr(g.x, attr)()


### PR DESCRIPTION
Closes https://github.com/dask-contrib/dask-expr/issues/840

This change is not entirely necessary given that the "correct" result is trivial. However, I think it's best to provide a bit of information to the user since it's easy.