### PR TITLE
Drop columns in groupby.size

### DIFF
--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -533,6 +533,24 @@ class Size(SingleAggregation):
     groupby_chunk = M.size
     groupby_aggregate = M.sum
 
+    def _simplify_down(self):
+        if (
+            self._slice is not None
+            and not isinstance(self._slice, list)
+            or self.frame.ndim == 1
+        ):
+            # Single projections influence the result and are allowed
+            return
+
+        # We can remove every column since pandas reduces to a Series anyway
+        by_columns = self._by_columns
+        if set(by_columns) == set(self.frame.columns):
+            return
+
+        slice_idx = self._parameters.index("_slice")
+        ops = [op if i != slice_idx else None for i, op in enumerate(self.operands)]
+        return type(self)(self.frame[by_columns], *ops[1:])
+
 
 class IdxMin(SingleAggregation):
     groupby_chunk = M.idxmin

--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -539,11 +539,13 @@ class Size(SingleAggregation):
             and not isinstance(self._slice, list)
             or self.frame.ndim == 1
         ):
-            # Single projections influence the result and are allowed
+            # Scalar slices influence the result and are allowed, e.g. the name of
+            # the series is different
             return
 
         # We can remove every column since pandas reduces to a Series anyway
         by_columns = self._by_columns
+        by_columns = [c for c in by_columns if c in self.frame.columns]
         if set(by_columns) == set(self.frame.columns):
             return
 

--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -539,7 +539,7 @@ class Size(SingleAggregation):
             and not isinstance(self._slice, list)
             or self.frame.ndim == 1
         ):
-            # Scalar slices influence the result and are allowed, e.g. the name of
+            # Scalar slices influence the result and are allowed, i.e., the name of
             # the series is different
             return
 

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -932,3 +932,9 @@ def test_groupby_size_drop_columns(df, pdf):
     result = df[["y", "z"]].groupby(df.x).size()
     assert result.simplify()._name == df[[]].groupby(df.x).size().simplify()._name
     assert_eq(result, pdf[["y", "z"]].groupby(pdf.x).size())
+
+    pdf = pdf.set_index("x")
+    df = from_pandas(pdf, npartitions=10)
+    result = df.groupby("x").size()
+    assert_eq(result, pdf.groupby("x").size())
+    assert result.simplify()._name == df[[]].groupby("x").size().simplify()._name

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -907,3 +907,20 @@ def test_series_groupby_cumfunc_with_named_index(npartitions, func):
     expected = getattr(df["y"].groupby("x"), func)()
     result = getattr(ddf["y"].groupby("x"), func)()
     assert_eq(result, expected)
+
+
+def test_groupby_size_drop_columns(df, pdf):
+    result = df.groupby("x").size()
+    assert result.simplify()._name == df[["x"]].groupby("x").size().simplify()._name
+    assert_eq(result, pdf.groupby("x").size())
+
+    result = df.groupby("x")[["y", "z"]].size()
+    assert result.simplify()._name == df[["x"]].groupby("x").size().simplify()._name
+    assert_eq(result, pdf.groupby("x")[["y", "z"]].size())
+
+    assert_eq(df.groupby("x").y.size(), pdf.groupby("x").y.size())
+    assert_eq(df.x.groupby(df.x).size(), pdf.x.groupby(pdf.x).size())
+
+    result = df[["y", "z"]].groupby(df.x).size()
+    assert result.simplify()._name == df[[]].groupby(df.x).size().simplify()._name
+    assert_eq(result, pdf[["y", "z"]].groupby(pdf.x).size())


### PR DESCRIPTION
We don't need any columns for size, so drop all off them