### PR TITLE
Add list conversion to ``determine_column_projection``

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -3361,7 +3361,7 @@ def determine_column_projection(expr, parent, dependents, additional_columns=Non
         column_union = sorted(flattened_columns)
     except TypeError:
         # mixed type columns
-        column_union = _sort_mixed(pd.Index(list(flattened_columns)))
+        column_union = _sort_mixed(pd.Index(list(flattened_columns))).tolist()
     if (
         len(column_union) == 1
         and parent.ndim == 1

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -1373,13 +1373,17 @@ def test_columns_assignment():
 
 
 def test_parent_mixed_column_assignment():
-    pdf = pd.DataFrame(list(range(100)))
+    pdf = pd.DataFrame(list(range(20)))
     df = from_pandas(pdf, npartitions=4)
-    df["fold"] = 0
-    df["fold"] = df["fold"].map_partitions(
-        lambda x: pd.Series(np.random.randint(0, 4, len(x)))
+    df["a"] = 0
+    df["a"] = df["a"].map_partitions(
+        lambda x: pd.Series(
+            np.full(len(x), 1, dtype="int"),
+            index=x.index,
+        )
     )
-    df.simplify()
+    pdf["a"] = pd.Series(np.full(len(pdf), 1, dtype="int"))
+    assert_eq(df, pdf)
 
 
 def test_setitem_triggering_realign():

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -1372,6 +1372,16 @@ def test_columns_assignment():
     assert_eq(df, ddf)
 
 
+def test_parent_mixed_column_assignment():
+    pdf = pd.DataFrame(list(range(100)))
+    df = from_pandas(pdf, npartitions=4)
+    df["fold"] = 0
+    df["fold"] = df["fold"].map_partitions(
+        lambda x: pd.Series(np.random.randint(0, 4, len(x)))
+    )
+    df.simplify()
+
+
 def test_setitem_triggering_realign():
     a = from_pandas(pd.DataFrame({"A": range(12)}), npartitions=3)
     b = from_pandas(pd.Series(range(12), name="B"), npartitions=4)


### PR DESCRIPTION
After https://github.com/dask-contrib/dask-expr/pull/842, I'm seeing a new test failure in `dask_cudf`. It seems that we need to convert the output of `_sort_mixed` to `list`.