### PR TITLE
Minor change to ``ShuffleReduce._lower``

### DIFF
--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -236,15 +236,16 @@ class ShuffleReduce(Expr):
             shuffled = SetIndexBlockwise(shuffled, split_by, True, divisions)
 
         # Convert back to Series if necessary
-        if is_series_like(self._meta):
-            shuffled = shuffled[shuffled.columns[0]]
-        elif is_index_like(self._meta):
-            column = shuffled.columns[0]
-            shuffled = Index(
-                SetIndexBlockwise(shuffled, column, True, shuffled.divisions)
-            )
-            if column == "__index__":
-                shuffled = RenameSeries(shuffled, self.frame._meta.name)
+        if self.shuffle_by_index is not False:
+            if is_series_like(self._meta):
+                shuffled = shuffled[shuffled.columns[0]]
+            elif is_index_like(self._meta):
+                column = shuffled.columns[0]
+                shuffled = Index(
+                    SetIndexBlockwise(shuffled, column, True, shuffled.divisions)
+                )
+                if column == "__index__":
+                    shuffled = RenameSeries(shuffled, self.frame._meta.name)
 
         # Blockwise aggregate
         result = Aggregate(


### PR DESCRIPTION
I'm working on the "cudf" backend for dask-expr, and I noticed that a small piece of logic in `ShuffleReduce._lower` only works when the `DecomposableGroupbyAggregation` uses the index to store the group keys. The dask-cudf approach currently keeps everything in the columns (partly for historical reasons).

I know there are several workarounds I can pursue. However, the code "just works" with the small tweak in this PR. (and I'm pretty sure the change makes sense either way)