### PR TITLE
Rewrite filters to decompose or conditions

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1812,6 +1812,13 @@ class Filter(Blockwise):
     operation = operator.getitem
 
     def _simplify_up(self, parent, dependents):
+        if isinstance(self.predicate, Or):
+            result = rewrite_filters(self.predicate)
+            if result._name != self.predicate._name:
+                return type(parent)(
+                    type(self)(self.frame, result), *parent.operands[1:]
+                )
+
         if isinstance(parent, Filter) and not isinstance(self.frame, Filter):
             if not self.frame._filter_passthrough_available(self, dependents):
                 # We want to collect filters again when we can't move them
@@ -3509,6 +3516,78 @@ def is_filter_pushdown_available(expr, parent, dependents, allow_reduction=True)
     return _check_dependents_are_predicates(
         expr, others, parent, dependents, allow_reduction
     )
+
+
+def rewrite_filters(predicate):
+    """Rewriting a filter to decompose OR clauses. If a predicate part is part of
+    all OR clauses, we can move it to the front so that we can push it down.
+    """
+    or_components = _get_predicate_components(predicate, [])
+    if len(or_components) == 1:
+        return predicate
+    result = _replace_common_or_components(or_components[0], or_components[1:])
+    if result is None:
+        return predicate
+    return result
+
+
+def _get_predicate_components(predicate, components, type_=Or):
+    if not isinstance(predicate, type_):
+        components.append(predicate)
+        return components
+    if isinstance(predicate.left, type_):
+        components = _get_predicate_components(predicate.left, components, type_)
+    else:
+        components.append(predicate.left)
+    if isinstance(predicate.right, type_):
+        components = _get_predicate_components(predicate.right, components, type_)
+    else:
+        components.append(predicate.right)
+    return components
+
+
+def _convert_mapping(components):
+    return dict(zip([e._name for e in components], components))
+
+
+def _replace_common_or_components(expr, or_components):
+    and_component = _get_predicate_components(expr, [], type_=And)
+    mapping = _convert_mapping(and_component)
+    and_components = [
+        _get_predicate_components(c, [], type_=And) for c in or_components
+    ]
+    and_components = list(map(_convert_mapping, and_components))
+
+    replacements = []
+    for c in mapping.keys():
+        if all(c in comp for comp in and_components):
+            # We can pull this component out if it's part of all or components
+            replacements.append(c)
+    if len(replacements) == 0:
+        # exit if we can't replace anything
+        return
+
+    outer_component = mapping[replacements[0]]
+    for r in replacements[1:]:
+        # construct the outer component
+        outer_component = outer_component & mapping[r]
+
+    #
+    result_components = []
+    for comp in [mapping] + and_components:
+        keep_components = [c for c in comp if c not in replacements]
+        if len(keep_components) == 0:
+            # Just return outer_component if we can replace a whole OR component
+            return outer_component
+        result_component = comp[keep_components[0]]
+        for c in keep_components[1:]:
+            result_component = result_component & comp[c]
+        result_components.append(result_component)
+
+    or_component = result_components[0]
+    for c in result_components[1:]:
+        or_component = or_component | c
+    return outer_component & or_component
 
 
 def _check_dependents_are_predicates(

--- a/dask_expr/tests/test_predicate_pushdown.py
+++ b/dask_expr/tests/test_predicate_pushdown.py
@@ -1,0 +1,59 @@
+import pytest
+
+from dask_expr import from_pandas
+from dask_expr._expr import rewrite_filters
+from dask_expr.tests._util import _backend_library, assert_eq
+
+pd = _backend_library()
+
+
+@pytest.fixture
+def pdf():
+    pdf = pd.DataFrame({"x": range(100), "a": 1, "b": 2})
+    pdf["y"] = pdf.x // 7  # Not unique; duplicates span different partitions
+    yield pdf
+
+
+@pytest.fixture
+def df(pdf):
+    yield from_pandas(pdf, npartitions=10)
+
+
+def test_rewrite_filters(df):
+    predicate = (df.x == 1) | (df.x == 1)
+    expected = df.x == 1
+    assert rewrite_filters(predicate.expr)._name == expected._name
+
+    predicate = (df.x == 1) | ((df.x == 1) & (df.y == 2))
+    expected = df.x == 1
+    assert rewrite_filters(predicate.expr)._name == expected._name
+
+    predicate = ((df.x == 1) & (df.y == 3)) | ((df.x == 1) & (df.y == 2))
+    expected = (df.x == 1) & ((df.y == 3) | (df.y == 2))
+    assert rewrite_filters(predicate.expr)._name == expected._name
+
+    predicate = ((df.x == 1) & (df.y == 3) & (df.a == 1)) | (
+        (df.x == 1) & (df.y == 2) & (df.a == 1)
+    )
+    expected = ((df.x == 1) & (df.a == 1)) & ((df.y == 3) | (df.y == 2))
+    assert rewrite_filters(predicate.expr)._name == expected._name
+
+    predicate = (df.x == 1) | (df.y == 1)
+    assert rewrite_filters(predicate.expr)._name == predicate._name
+
+    predicate = df.x == 1
+    assert rewrite_filters(predicate.expr)._name == predicate._name
+
+    predicate = (df.x.isin([1, 2, 3]) & (df.y == 3)) | (
+        df.x.isin([1, 2, 3]) & (df.y == 2)
+    )
+    expected = df.x.isin([1, 2, 3]) & ((df.y == 3) | (df.y == 2))
+    assert rewrite_filters(predicate.expr)._name == expected._name
+
+
+def test_rewrite_filters_query(df, pdf):
+    result = df[((df.x == 1) & (df.y > 1)) | ((df.x == 1) & (df.y > 2))]
+    result = result[["x"]]
+    expected = pdf[((pdf.x == 1) & (pdf.y > 1)) | ((pdf.x == 1) & (pdf.y > 2))]
+    expected = expected[["x"]]
+    assert_eq(result, expected)


### PR DESCRIPTION
I took a quick stab at this, it's a bit naive, but it can deal with filters that aren't too complex. query 19 is an example that can be handled with this implementation. We can make this smarter as we go if we want.