### PR TITLE
DNM: Handle pipeline breakers through avoiding reuse

### DIFF
--- a/dask_expr/_core.py
+++ b/dask_expr/_core.py
@@ -53,6 +53,12 @@ class Expr:
     def _tune_up(self, parent):
         return None
 
+    def _pipe_down(self):
+        return None
+
+    def _pipe_up(self, parent):
+        return None
+
     def _cull_down(self):
         return None
 
@@ -342,6 +348,7 @@ class Expr:
         while True:
             dependents = collect_dependents(expr)
             new = expr.simplify_once(dependents=dependents, simplified={})
+            new = new.rewrite("pipe")
             if new._name == expr._name:
                 break
             expr = new

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2102,11 +2102,9 @@ class ResetIndex(Elemwise):
             return self._filter_simplification(parent, predicate)
 
         if isinstance(parent, Projection):
-            if (
-                self.frame.ndim == 1
-                and not self.drop
-                and not isinstance(parent.operand("columns"), list)
-            ):
+            if self.frame.ndim == 1 and not self.drop:
+                if isinstance(parent.operand("columns"), list):
+                    return
                 col = parent.operand("columns")
                 if col in (self.name, "index"):
                     return

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -320,6 +320,7 @@ class FromPandas(PartitionsFiltered, BlockwiseIO):
         "columns",
         "_partitions",
         "_series",
+        "_pipeline_breaker_counter",
     ]
     _defaults = {
         "npartitions": None,
@@ -328,6 +329,7 @@ class FromPandas(PartitionsFiltered, BlockwiseIO):
         "_partitions": None,
         "_series": False,
         "chunksize": None,
+        "_pipeline_breaker_counter": None,
     }
     _pd_length_stats = None
     _absorb_projections = True

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -402,6 +402,7 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
         "_partitions",
         "_series",
         "_dataset_info_cache",
+        "_pipeline_breaker_counter",
     ]
     _defaults = {
         "columns": None,
@@ -422,6 +423,7 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
         "_partitions": None,
         "_series": False,
         "_dataset_info_cache": None,
+        "_pipeline_breaker_counter": None,
     }
     _pq_length_stats = None
     _absorb_projections = True


### PR DESCRIPTION
This is a naive implementation that recomputes pipeline breakers (https://github.com/dask-contrib/dask-expr/issues/854) to avoid OOM errors. This PR has a list of deficiencies, namely:

- We always go back to IO Nodes, anything that shuffles before we run into a reduction should be fine
- We should track references on the Expression, this would mean that the pipeline breaker modifications would be a simple "_simplify_down`` step. We are messing with nodes deep down in the tree at the moment which means that their dependents aren't updated properly. That's the main reason that it currently is a separate optimization step
- Not all reductions are supported
- I *think* we have to lower merges into different expressions to make this work properly

Just putting this up here for others to potentially mess around with. This is most helpful for query 21 in tpch benchmarks. The query is super slow without https://github.com/dask/dask/pull/10922 though