### PR TITLE
Allow `columns` argument to be mandatory in `from_map`

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -4890,14 +4890,15 @@ def from_map(
 
     # Check if `func` supports column projection
     allow_projection = False
+    columns_arg_required = False
     if param := inspect.signature(func).parameters.get("columns", None):
         allow_projection = True
-        if param.default is param.empty:
+        columns_arg_required = True
+        if meta is no_default and param.default is param.empty:
             raise TypeError(
-                "Argument `func` of `from_map` has a `columns` parameter, but "
-                "it is not optional. The `columns` parameter is expected to be "
-                "an optional parameter such that if no argument is supplied, "
-                "the function will produce all available columns."
+                "Argument `func` of `from_map` has a required `columns` "
+                " parameter and not `meta` provided."
+                "Either provide `meta` yourself or make `columns` an optional argument."
             )
     elif isinstance(func, DataFrameIOFunction):
         warnings.warn(
@@ -4920,6 +4921,7 @@ def from_map(
                 columns,
                 args,
                 kwargs,
+                columns_arg_required,
                 meta,
                 enforce_metadata,
                 divisions,

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -4891,8 +4891,8 @@ def from_map(
     columns_arg_required = False
     if param := inspect.signature(func).parameters.get("columns", None):
         allow_projection = True
-        columns_arg_required = True
-        if meta is no_default and param.default is param.empty:
+        columns_arg_required = param.default is param.empty
+        if meta is no_default and columns_arg_required:
             raise TypeError(
                 "Argument `func` of `from_map` has a required `columns` "
                 " parameter and not `meta` provided."

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -4858,8 +4858,6 @@ def from_map(
     will support column projection (via ``simplify``) if
     the ``func`` argument has "columns" in its signature.
 
-    The `columns` argument is expected to be an optional argument such that if
-    no argument is supplied, the function will produce all available columns.
     """
     from dask.dataframe.io.utils import DataFrameIOFunction
 

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -228,6 +228,7 @@ class FromMapProjectable(FromMap):
         "columns",
         "args",
         "kwargs",
+        "columns_arg_required",
         "user_meta",
         "enforce_metadata",
         "user_divisions",
@@ -265,9 +266,9 @@ class FromMapProjectable(FromMap):
     @functools.cached_property
     def kwargs(self):
         options = self.operand("kwargs")
-        if self.columns_operand:
+        if self.columns_arg_required or self.columns_operand:
             options = options.copy()
-            options["columns"] = self.columns_operand
+            options["columns"] = self.columns
         return options
 
     @functools.cached_property

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -463,6 +463,15 @@ def test_from_map(tmpdir, meta, label, allow_projection, enforce_metadata):
     assert_eq(result, pdf["a"], check_index=False)
 
 
+def func(path, columns):
+    raise NotImplementedError("This shouldn't ever be called")
+
+
+def test_from_map_columns_required(tmpdir):
+    with pytest.raises(TypeError, match=r"columns.*optional"):
+        from_map(func, ["foo"])
+
+
 def test_from_array():
     arr = np.random.randint(1, 100, (100,))
     assert_eq(from_array(arr, chunksize=5), pd.Series(arr))

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -7,7 +7,7 @@ import numpy as np
 import pyarrow.parquet as pq
 import pytest
 from dask.array.utils import assert_eq as array_assert_eq
-from dask.dataframe.utils import assert_eq
+from dask.dataframe.utils import assert_eq, make_meta
 
 from dask_expr import (
     DataFrame,
@@ -467,9 +467,23 @@ def func(path, columns):
     raise NotImplementedError("This shouldn't ever be called")
 
 
-def test_from_map_columns_required(tmpdir):
+def func2(path, columns):
+    return pd.DataFrame({"a": range(10), "b": range(10)})
+
+
+def test_from_map_columns_required():
     with pytest.raises(TypeError, match=r"columns.*optional"):
         from_map(func, ["foo"])
+    meta = make_meta(func2("foo", None))
+    ddf = from_map(func2, ["foo"], meta=meta)
+    ddf_expected = from_pandas(func2("foo", None), npartitions=1)
+
+    assert_eq(ddf, ddf_expected, check_divisions=False)
+
+    actual = from_map(func2, ["foo"], meta=meta)[["a"]].optimize()
+    expected = from_map(func2, ["foo"], meta=meta, columns=["a"]).optimize()
+
+    assert actual._name == expected._name
 
 
 def test_from_array():


### PR DESCRIPTION
`from_map` is performing some magic if the function that is being provided has a `columns` kwarg. However, if that columns `kwarg` is not optional, the magic breaks down. Status on main is that it raises this confusing error message

```
func() missing 1 required positional argument: 'columns'
```

this change adds functionality that allows the function to use a mandatory `columns` argument

Stumbled over this while trying to use it in https://github.com/dask-contrib/dask-deltatable/pull/69

Note: If the `meta` is not provided we have to raise because we don't have a way to generate the meta ourselves but in this case we're raising now a clean exception