### PR TITLE
Parquet reader using Pyarrow FileSystem

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -4641,7 +4641,7 @@ def read_parquet(
             raise NotImplementedError(
                 "split_row_groups is not supported when using the pyarrow filesystem."
             )
-        if blocksize != "default":
+        if blocksize is not None and blocksize != "default":
             raise NotImplementedError(
                 "blocksize is not supported when using the pyarrow filesystem."
             )

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -4651,7 +4651,7 @@ def read_parquet(
         or isinstance(filesystem, str)
         and filesystem.lower() in ("arrow", "pyarrow")
     ):
-        if parse_version(pa.__version__) <= parse_version("15.0.0"):
+        if parse_version(pa.__version__) < parse_version("15.0.0"):
             raise ValueError(
                 "pyarrow>=15.0.0 is required to use the pyarrow filesystem."
             )

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -760,43 +760,19 @@ class ReadParquetPyarrowFS(ReadParquet):
             # batch_readahead=16,
             # fragment_readahead=4,
             fragment_scan_options=pa.dataset.ParquetFragmentScanOptions(
-                # use_buffered_stream=False,
-                # buffer_size=8192,
                 pre_buffer=True,
                 cache_options=pa.CacheOptions(
-                    # hole_size_limit=parse_bytes("8 KiB"),
-                    # range_size_limit=parse_bytes("32.00 MiB"),
                     hole_size_limit=parse_bytes("4 MiB"),
                     range_size_limit=parse_bytes("32.00 MiB"),
-                    # I've seen this actually slowing us down, e.g. on TPCHQ14
-                    lazy=False,
-                    # If we disable lazy we can remove this as well.
-                    prefetch_limit=500,
                 ),
-                # thrift_string_size_limit=None,
-                # thrift_container_size_limit=None,
-                # decryption_config=None,
-                # page_checksum_verification=False,
             ),
             # TODO: Reconsider this. The OMP_NUM_THREAD variable makes it harmful to enable this
             use_threads=True,
         )
         df = table.to_pandas(
             types_mapper=_determine_type_mapper(),
-            # categories=None,
-            # strings_to_categorical=False,
-            # zero_copy_only=False,
-            # integer_object_nulls=False,
-            # date_as_object=True,
-            # timestamp_as_object=False,
             use_threads=False,
-            # deduplicate_objects=True,
-            # ignore_metadata=False,
-            # safe=True,
-            # split_blocks=False,
             self_destruct=True,
-            # maps_as_pydicts=None,
-            # coerce_temporal_nanoseconds=False,
         )
         return df
 

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -4,6 +4,7 @@ import contextlib
 import itertools
 import operator
 import warnings
+from abc import abstractmethod
 from collections import defaultdict
 from functools import cached_property
 
@@ -484,27 +485,6 @@ def _determine_type_mapper(
 
 
 class ReadParquet(PartitionsFiltered, BlockwiseIO):
-    _parameters = [
-        "path",
-        "columns",
-        "filters",
-        "categories",
-        "index",
-        "storage_options",
-        "filesystem",
-        "kwargs",
-        "_dataset_info_cache",
-    ]
-    _defaults = {
-        "columns": None,
-        "filters": None,
-        "categories": None,
-        "index": None,
-        "storage_options": None,
-        "filesystem": None,
-        "kwargs": None,
-        "_dataset_info_cache": None,
-    }
     _pq_length_stats = None
     _absorb_projections = True
     _filter_passthrough = False
@@ -589,6 +569,7 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
             return meta[columns]
         return meta
 
+    @abstractmethod
     def _divisions(self):
         raise NotImplementedError
 
@@ -716,17 +697,6 @@ class ReadParquetPyarrowFS(ReadParquet):
 
     def _divisions(self):
         return tuple([None] * (len(self.fragments) + 1))
-
-    @property
-    def _meta(self):
-        meta = self._dataset_info["base_meta"]
-        columns = _convert_to_list(self.operand("columns"))
-        if self._series:
-            assert len(columns) > 0
-            return meta[columns[0]]
-        elif columns is not None:
-            return meta[columns]
-        return meta
 
     @property
     def fragments(self):

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -124,7 +124,8 @@ def test_read_csv_keywords(tmpdir):
 def test_io_fusion_blockwise(tmpdir):
     pdf = pd.DataFrame({c: range(10) for c in "abcdefghijklmn"})
     dd.from_pandas(pdf, 3).to_parquet(tmpdir)
-    df = read_parquet(tmpdir)["a"].fillna(10).optimize()
+    read_parq = read_parquet(tmpdir)
+    df = read_parq["a"].fillna(10).optimize()
     assert df.npartitions == 2
     assert len(df.__dask_graph__()) == 2
     graph = (
@@ -133,7 +134,9 @@ def test_io_fusion_blockwise(tmpdir):
         .optimize(fuse=False)
         .__dask_graph__()
     )
-    assert any("readparquet-fused" in key[0] for key in graph.keys())
+    assert any(
+        f"{read_parq._expr._name.split('-')[0]}-fused" in key[0] for key in graph.keys()
+    )
 
 
 def test_repartition_io_fusion_blockwise(tmpdir):

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -21,8 +21,7 @@ from dask_expr import (
     read_csv,
     read_parquet,
 )
-from dask_expr._expr import Expr, Lengths, Literal, Replace
-from dask_expr._reductions import Len
+from dask_expr._expr import Expr, Replace
 from dask_expr.io import FromArray, FromMap, ReadCSV, ReadParquet, parquet
 from dask_expr.tests._util import _backend_library
 
@@ -122,85 +121,6 @@ def test_read_csv_keywords(tmpdir):
     assert_eq(df, expected)
 
 
-@pytest.mark.skip()
-def test_predicate_pushdown(tmpdir):
-    original = pd.DataFrame(
-        {
-            "a": [1, 2, 3, 4, 5] * 10,
-            "b": [0, 1, 2, 3, 4] * 10,
-            "c": range(50),
-            "d": [6, 7] * 25,
-            "e": [8, 9] * 25,
-        }
-    )
-    fn = _make_file(tmpdir, format="parquet", df=original)
-    df = read_parquet(fn)
-    assert_eq(df, original)
-    x = df[df.a == 5][df.c > 20]["b"]
-    y = optimize(x, fuse=False)
-    assert isinstance(y.expr, ReadParquet)
-    assert ("a", "==", 5) in y.expr.operand("filters")[0]
-    assert ("c", ">", 20) in y.expr.operand("filters")[0]
-    assert list(y.columns) == ["b"]
-
-    # Check computed result
-    y_result = y.compute()
-    assert y_result.name == "b"
-    assert len(y_result) == 6
-    assert (y_result == 4).all()
-
-
-@pytest.mark.skip()
-def test_predicate_pushdown_compound(tmpdir):
-    pdf = pd.DataFrame(
-        {
-            "a": [1, 2, 3, 4, 5] * 10,
-            "b": [0, 1, 2, 3, 4] * 10,
-            "c": range(50),
-            "d": [6, 7] * 25,
-            "e": [8, 9] * 25,
-        }
-    )
-    fn = _make_file(tmpdir, format="parquet", df=pdf)
-    df = read_parquet(fn)
-
-    # Test AND
-    x = df[(df.a == 5) & (df.c > 20)]["b"]
-    y = optimize(x, fuse=False)
-    assert isinstance(y.expr, ReadParquet)
-    assert {("c", ">", 20), ("a", "==", 5)} == set(y.filters[0])
-    assert_eq(
-        y,
-        pdf[(pdf.a == 5) & (pdf.c > 20)]["b"],
-        check_index=False,
-    )
-
-    # Test OR
-    x = df[(df.a == 5) | (df.c > 20)]
-    x = x[x.b != 0]["b"]
-    y = optimize(x, fuse=False)
-    assert isinstance(y.expr, ReadParquet)
-    filters = [set(y.filters[0]), set(y.filters[1])]
-    assert {("c", ">", 20), ("b", "!=", 0)} in filters
-    assert {("a", "==", 5), ("b", "!=", 0)} in filters
-    expect = pdf[(pdf.a == 5) | (pdf.c > 20)]
-    expect = expect[expect.b != 0]["b"]
-    assert_eq(
-        y,
-        expect,
-        check_index=False,
-    )
-
-    # Test OR and AND
-    x = df[((df.a == 5) | (df.c > 20)) & (df.b != 0)]["b"]
-    z = optimize(x, fuse=False)
-    assert isinstance(z.expr, ReadParquet)
-    filters = [set(z.filters[0]), set(z.filters[1])]
-    assert {("c", ">", 20), ("b", "!=", 0)} in filters
-    assert {("a", "==", 5), ("b", "!=", 0)} in filters
-    assert_eq(y, z)
-
-
 def test_io_fusion_blockwise(tmpdir):
     pdf = pd.DataFrame({c: range(10) for c in "abcdefghijklmn"})
     dd.from_pandas(pdf, 3).to_parquet(tmpdir)
@@ -289,27 +209,6 @@ def test_parquet_complex_filters(tmpdir):
     assert_eq(got.optimize(), expect)
 
 
-def test_parquet_len(tmpdir):
-    df = read_parquet(_make_file(tmpdir))
-    pdf = df.compute()
-
-    assert len(df[df.a > 5]) == len(pdf[pdf.a > 5])
-
-    s = (df["b"] + 1).astype("Int32")
-    assert len(s) == len(pdf)
-
-    assert isinstance(Len(s.expr).optimize(), Literal)
-    assert isinstance(Lengths(s.expr).optimize(), Literal)
-
-
-def test_parquet_len_filter(tmpdir):
-    df = read_parquet(_make_file(tmpdir))
-    expr = Len(df[df.c > 0].expr)
-    result = expr.simplify()
-    for rp in result.find_operations(ReadParquet):
-        assert rp.operand("columns") == ["c"] or rp.operand("columns") == []
-
-
 @pytest.mark.parametrize("optimize", [True, False])
 def test_from_dask_dataframe(optimize):
     ddf = dd.from_dict({"a": range(100)}, npartitions=10)
@@ -334,35 +233,6 @@ def test_to_dask_array(optimize):
     darr = df.to_dask_array(optimize=optimize)
     assert isinstance(darr, da.Array)
     array_assert_eq(darr, pdf.values)
-
-
-@pytest.mark.parametrize("write_metadata_file", [True, False])
-def test_to_parquet(tmpdir, write_metadata_file):
-    pdf = pd.DataFrame({"x": [1, 4, 3, 2, 0, 5]})
-    df = from_pandas(pdf, npartitions=2)
-
-    # Check basic parquet round trip
-    df.to_parquet(tmpdir, write_metadata_file=write_metadata_file)
-    df2 = read_parquet(tmpdir, calculate_divisions=True)
-    assert_eq(df, df2)
-
-    # Check overwrite behavior
-    df["new"] = df["x"] + 1
-    df.to_parquet(tmpdir, overwrite=True, write_metadata_file=write_metadata_file)
-    df2 = read_parquet(tmpdir, calculate_divisions=True)
-    assert_eq(df, df2)
-
-    # Check that we cannot overwrite a path we are
-    # reading from in the same graph
-    with pytest.raises(ValueError, match="Cannot overwrite"):
-        df2.to_parquet(tmpdir, overwrite=True)
-
-
-def test_to_parquet_engine(tmpdir):
-    pdf = pd.DataFrame({"x": [1, 4, 3, 2, 0, 5]})
-    df = from_pandas(pdf, npartitions=2)
-    with pytest.raises(NotImplementedError, match="not supported"):
-        df.to_parquet(tmpdir + "engine.parquet", engine="fastparquet")
 
 
 @pytest.mark.parametrize(

--- a/dask_expr/io/tests/test_parquet.py
+++ b/dask_expr/io/tests/test_parquet.py
@@ -1,18 +1,18 @@
 import os
 
 import pandas as pd
-import pyarrow as pa
 import pytest
 from dask.dataframe.utils import assert_eq
+from pyarrow import fs
 
-from dask_expr import from_pandas, optimize, read_parquet
+from dask_expr import from_pandas, read_parquet
 from dask_expr._expr import Lengths, Literal
 from dask_expr._reductions import Len
 from dask_expr.io import ReadParquet
 
 
 def _make_file(dir, df=None):
-    fn = os.path.join(str(dir), f"myfile.parquet")
+    fn = os.path.join(str(dir), "myfile.parquet")
     if df is None:
         df = pd.DataFrame({c: range(10) for c in "abcde"})
     df.to_parquet(fn)
@@ -74,90 +74,50 @@ def test_to_parquet_engine(tmpdir):
         df.to_parquet(tmpdir + "engine.parquet", engine="fastparquet")
 
 
-@pytest.mark.skip()
-def test_predicate_pushdown(tmpdir):
-    original = pd.DataFrame(
-        {
-            "a": [1, 2, 3, 4, 5] * 10,
-            "b": [0, 1, 2, 3, 4] * 10,
-            "c": range(50),
-            "d": [6, 7] * 25,
-            "e": [8, 9] * 25,
-        }
-    )
-    fn = _make_file(tmpdir, df=original)
-    df = read_parquet(fn)
-    assert_eq(df, original)
-    x = df[df.a == 5][df.c > 20]["b"]
-    y = optimize(x, fuse=False)
-    assert isinstance(y.expr, ReadParquet)
-    assert ("a", "==", 5) in y.expr.operand("filters")[0]
-    assert ("c", ">", 20) in y.expr.operand("filters")[0]
-    assert list(y.columns) == ["b"]
-
-    # Check computed result
-    y_result = y.compute()
-    assert y_result.name == "b"
-    assert len(y_result) == 6
-    assert (y_result == 4).all()
-
-
-@pytest.mark.skip()
-def test_predicate_pushdown_compound(tmpdir):
-    pdf = pd.DataFrame(
-        {
-            "a": [1, 2, 3, 4, 5] * 10,
-            "b": [0, 1, 2, 3, 4] * 10,
-            "c": range(50),
-            "d": [6, 7] * 25,
-            "e": [8, 9] * 25,
-        }
-    )
-    fn = _make_file(tmpdir, df=pdf)
-    df = read_parquet(fn)
-
-    # Test AND
-    x = df[(df.a == 5) & (df.c > 20)]["b"]
-    y = optimize(x, fuse=False)
-    assert isinstance(y.expr, ReadParquet)
-    assert {("c", ">", 20), ("a", "==", 5)} == set(y.filters[0])
-    assert_eq(
-        y,
-        pdf[(pdf.a == 5) & (pdf.c > 20)]["b"],
-        check_index=False,
-    )
-
-    # Test OR
-    x = df[(df.a == 5) | (df.c > 20)]
-    x = x[x.b != 0]["b"]
-    y = optimize(x, fuse=False)
-    assert isinstance(y.expr, ReadParquet)
-    filters = [set(y.filters[0]), set(y.filters[1])]
-    assert {("c", ">", 20), ("b", "!=", 0)} in filters
-    assert {("a", "==", 5), ("b", "!=", 0)} in filters
-    expect = pdf[(pdf.a == 5) | (pdf.c > 20)]
-    expect = expect[expect.b != 0]["b"]
-    assert_eq(
-        y,
-        expect,
-        check_index=False,
-    )
-
-    # Test OR and AND
-    x = df[((df.a == 5) | (df.c > 20)) & (df.b != 0)]["b"]
-    z = optimize(x, fuse=False)
-    assert isinstance(z.expr, ReadParquet)
-    filters = [set(z.filters[0]), set(z.filters[1])]
-    assert {("c", ">", 20), ("b", "!=", 0)} in filters
-    assert {("a", "==", 5), ("b", "!=", 0)} in filters
-    assert_eq(y, z)
-
-
 def test_pyarrow_filesystem(parquet_file):
-    from pyarrow import fs
+    filesystem = fs.LocalFileSystem()
 
-    fs = fs.LocalFileSystem()
-
-    df_pa = read_parquet(parquet_file, filesystem=fs)
+    df_pa = read_parquet(parquet_file, filesystem=filesystem)
     df = read_parquet(parquet_file)
     assert assert_eq(df, df_pa)
+
+
+def test_pyarrow_filesystem_filters(parquet_file):
+    filesystem = fs.LocalFileSystem()
+
+    df_pa = read_parquet(parquet_file, filesystem=filesystem)
+    df_pa = df_pa[df_pa.c == 1]
+    expected = read_parquet(
+        parquet_file, filesystem=filesystem, filters=[[("c", "==", 1)]]
+    )
+    assert df_pa.optimize()._name == expected.optimize()._name
+    assert len(df_pa.compute()) == 1
+
+
+def test_partition_pruning(tmpdir):
+    filesystem = fs.LocalFileSystem()
+    df = from_pandas(
+        pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5] * 10,
+                "b": range(50),
+            }
+        ),
+        npartitions=2,
+    )
+    df.to_parquet(tmpdir, partition_on=["a"])
+    ddf = read_parquet(tmpdir, filesystem=filesystem)
+    ddf_filtered = read_parquet(
+        tmpdir, filters=[[("a", "==", 1)]], filesystem=filesystem
+    )
+    assert ddf_filtered.npartitions == ddf.npartitions // 5
+
+    ddf_optimize = read_parquet(tmpdir, filesystem=filesystem)
+    ddf_optimize = ddf_optimize[ddf_optimize.a == 1].optimize()
+    assert ddf_optimize.npartitions == ddf.npartitions // 5
+    assert_eq(
+        ddf_filtered,
+        ddf_optimize,
+        # FIXME ?
+        check_names=False,
+    )

--- a/dask_expr/io/tests/test_parquet.py
+++ b/dask_expr/io/tests/test_parquet.py
@@ -1,0 +1,146 @@
+import os
+
+import pandas as pd
+import pytest
+from dask.dataframe.utils import assert_eq
+
+from dask_expr import from_pandas, optimize, read_parquet
+from dask_expr._expr import Lengths, Literal
+from dask_expr._reductions import Len
+from dask_expr.io import ReadParquet
+
+
+def _make_file(dir, df=None):
+    fn = os.path.join(str(dir), f"myfile.{format}")
+    if df is None:
+        df = pd.DataFrame({c: range(10) for c in "abcde"})
+    df.to_parquet(fn)
+
+
+def test_parquet_len(tmpdir):
+    df = read_parquet(_make_file(tmpdir))
+    pdf = df.compute()
+
+    assert len(df[df.a > 5]) == len(pdf[pdf.a > 5])
+
+    s = (df["b"] + 1).astype("Int32")
+    assert len(s) == len(pdf)
+
+    assert isinstance(Len(s.expr).optimize(), Literal)
+    assert isinstance(Lengths(s.expr).optimize(), Literal)
+
+
+def test_parquet_len_filter(tmpdir):
+    df = read_parquet(_make_file(tmpdir))
+    expr = Len(df[df.c > 0].expr)
+    result = expr.simplify()
+    for rp in result.find_operations(ReadParquet):
+        assert rp.operand("columns") == ["c"] or rp.operand("columns") == []
+
+
+@pytest.mark.parametrize("write_metadata_file", [True, False])
+def test_to_parquet(tmpdir, write_metadata_file):
+    pdf = pd.DataFrame({"x": [1, 4, 3, 2, 0, 5]})
+    df = from_pandas(pdf, npartitions=2)
+
+    # Check basic parquet round trip
+    df.to_parquet(tmpdir, write_metadata_file=write_metadata_file)
+    df2 = read_parquet(tmpdir, calculate_divisions=True)
+    assert_eq(df, df2)
+
+    # Check overwrite behavior
+    df["new"] = df["x"] + 1
+    df.to_parquet(tmpdir, overwrite=True, write_metadata_file=write_metadata_file)
+    df2 = read_parquet(tmpdir, calculate_divisions=True)
+    assert_eq(df, df2)
+
+    # Check that we cannot overwrite a path we are
+    # reading from in the same graph
+    with pytest.raises(ValueError, match="Cannot overwrite"):
+        df2.to_parquet(tmpdir, overwrite=True)
+
+
+def test_to_parquet_engine(tmpdir):
+    pdf = pd.DataFrame({"x": [1, 4, 3, 2, 0, 5]})
+    df = from_pandas(pdf, npartitions=2)
+    with pytest.raises(NotImplementedError, match="not supported"):
+        df.to_parquet(tmpdir + "engine.parquet", engine="fastparquet")
+
+
+@pytest.mark.skip()
+def test_predicate_pushdown(tmpdir):
+    original = pd.DataFrame(
+        {
+            "a": [1, 2, 3, 4, 5] * 10,
+            "b": [0, 1, 2, 3, 4] * 10,
+            "c": range(50),
+            "d": [6, 7] * 25,
+            "e": [8, 9] * 25,
+        }
+    )
+    fn = _make_file(tmpdir, format="parquet", df=original)
+    df = read_parquet(fn)
+    assert_eq(df, original)
+    x = df[df.a == 5][df.c > 20]["b"]
+    y = optimize(x, fuse=False)
+    assert isinstance(y.expr, ReadParquet)
+    assert ("a", "==", 5) in y.expr.operand("filters")[0]
+    assert ("c", ">", 20) in y.expr.operand("filters")[0]
+    assert list(y.columns) == ["b"]
+
+    # Check computed result
+    y_result = y.compute()
+    assert y_result.name == "b"
+    assert len(y_result) == 6
+    assert (y_result == 4).all()
+
+
+@pytest.mark.skip()
+def test_predicate_pushdown_compound(tmpdir):
+    pdf = pd.DataFrame(
+        {
+            "a": [1, 2, 3, 4, 5] * 10,
+            "b": [0, 1, 2, 3, 4] * 10,
+            "c": range(50),
+            "d": [6, 7] * 25,
+            "e": [8, 9] * 25,
+        }
+    )
+    fn = _make_file(tmpdir, format="parquet", df=pdf)
+    df = read_parquet(fn)
+
+    # Test AND
+    x = df[(df.a == 5) & (df.c > 20)]["b"]
+    y = optimize(x, fuse=False)
+    assert isinstance(y.expr, ReadParquet)
+    assert {("c", ">", 20), ("a", "==", 5)} == set(y.filters[0])
+    assert_eq(
+        y,
+        pdf[(pdf.a == 5) & (pdf.c > 20)]["b"],
+        check_index=False,
+    )
+
+    # Test OR
+    x = df[(df.a == 5) | (df.c > 20)]
+    x = x[x.b != 0]["b"]
+    y = optimize(x, fuse=False)
+    assert isinstance(y.expr, ReadParquet)
+    filters = [set(y.filters[0]), set(y.filters[1])]
+    assert {("c", ">", 20), ("b", "!=", 0)} in filters
+    assert {("a", "==", 5), ("b", "!=", 0)} in filters
+    expect = pdf[(pdf.a == 5) | (pdf.c > 20)]
+    expect = expect[expect.b != 0]["b"]
+    assert_eq(
+        y,
+        expect,
+        check_index=False,
+    )
+
+    # Test OR and AND
+    x = df[((df.a == 5) | (df.c > 20)) & (df.b != 0)]["b"]
+    z = optimize(x, fuse=False)
+    assert isinstance(z.expr, ReadParquet)
+    filters = [set(z.filters[0]), set(z.filters[1])]
+    assert {("c", ">", 20), ("b", "!=", 0)} in filters
+    assert {("a", "==", 5), ("b", "!=", 0)} in filters
+    assert_eq(y, z)


### PR DESCRIPTION
Closes https://github.com/dask-contrib/dask-expr/issues/856

Primarily what isn't implemented is any sort of statistics collection, compaction or row group splitting.

The approach I'm taking here is pretty straight forward. I'm taking the pyarrow filesystem and am implementing the bare essentials to instantiate a parquet dataset and get the minimal metadata from the bucket and files (e.g. all paths, the schema). The expression then effectively tracks the `Fragment` objects that are being created by pyarrow. The Fragments expose all the API we truly care about
They can...
- load parquet metadata (not implemented yet)
- read the parquet file as pandas
- accept low level configuration options
- split themselves by row group (not implemented yet)

I think the most notable change besides relying directly and explicitly on the pyarrow filesystem (which is backed by C++ threads, i.e. no GIL/event loop blockage) is that I am configuring the `pre_buffer` cache options explicitly (this may actually also be possible with the existing implementation but I'm a little lost about how kwargs are passed through).

This is not really a cache but rathe a control for how many concurrent IO requests we are posting and how large/small those are allowed to become. The config options are briefly documented here https://github.com/apache/arrow/blob/a61f4af724cd06c3a9b4abd20491345997e532c0/python/pyarrow/io.pxi#L2139

The TLDR is primarily that the default `hole_size_limit` is a couple of orders of magnitude too small such that we get incredibly fragmented read requests.
Arrow actually ships with a utility that allows one to calculate appropriate config options easily [CacheOptions.from_network_metrics](https://github.com/apache/arrow/blob/a03d957b5b8d0425f9d5b6c98b6ee1efa56a1248/python/pyarrow/io.pxi#L2211-L2238)

Docs are in the C++ code here https://github.com/apache/arrow/blob/a61f4af724cd06c3a9b4abd20491345997e532c0/cpp/src/arrow/io/caching.cc#L49C28-L103 which also describes the math they are using and I think that makes sense. There is more documentation [here](https://github.com/apache/arrow/blob/a61f4af724cd06c3a9b4abd20491345997e532c0/cpp/src/arrow/io/caching.h#L44-L49) about the `lazy` and `prefetch_limit` options.

I started measuring S3 latencies for our benchmarking bucket (`coiled-runtime-ci`)

![image](https://github.com/dask-contrib/dask-expr/assets/8629629/d2b9392d-1102-49e3-8b7a-50530a860fbc)

Depending on how hot/cold the bucket is, the FirstByteLatency fluctuates between 15ms and 60ms wheres total request latency is somewhere between 30ms and 200ms. Plugging this stuff into the equation and assuming 50MiB/s per connection, we'll get

```python
import pyarrow as pa
copts = pa.CacheOptions.from_network_metrics(
    100, # I think we should take TotalRequestLatency as a guiding point
    50,  # 50MiB/s per connection
)
print(f"hole_size_limit={format_bytes(copts.hole_size_limit)}")
print(f"range_size_limit={format_bytes(copts.range_size_limit)}")
```

```
hole_size_limit=5.00 MiB
range_size_limit=45.00 MiB
```

So, while the range limit is fine you'll notice that the hole size is `MiB` whereas the default is `kiB`. Effectively, we're crippling ourselves with column projections because we're introducing more latency to the requests than we're saving on data transfer.

---

How does this translate to benchmarks?

Well, I haven't run many yet and am about to setup a full tpch run. So far I looked at two queries

# Q1

On the pyarrow generated dataset, this change isn't doing that much. The files are reasonably large and the fragmentation doesn't hurt us that badly. Also, with current main only about 40-50% of this query is actual IO. With this branch I can reduce IO to 30% which effectively shaves off about 10% total runtime

On the DuckDB dataset which contains many small rowgroups (i.e. chances of producing holes are very large and we'll end up with many fragmented reads) this change without further tuning boosts us by 25% easily

# Q14

This one was pointed out to be to suffer from P2P and parquet cross interference. The query is about 40% faster on this branch using the arrow filesystem. I suspect this is fsspec vs arrow more than the caching but I haven't investigated.

I'll post full results once available.