### PR TITLE
Add ``branch_id`` to distinguish between reusable branches and pipeline breakers

### DIFF
--- a/dask_expr/_concat.py
+++ b/dask_expr/_concat.py
@@ -45,7 +45,7 @@ class Concat(Expr):
             + ", "
             + ", ".join(
                 str(param) + "=" + str(operand)
-                for param, operand in zip(self._parameters, self.operands)
+                for param, operand in zip(self._parameters[:-1], self.operands)
                 if operand != self._defaults.get(param)
             )
         )

--- a/dask_expr/_concat.py
+++ b/dask_expr/_concat.py
@@ -45,7 +45,7 @@ class Concat(Expr):
             + ", "
             + ", ".join(
                 str(param) + "=" + str(operand)
-                for param, operand in zip(self._parameters[:-1], self.operands)
+                for param, operand in zip(self._parameters, self.operands)
                 if operand != self._defaults.get(param)
             )
         )

--- a/dask_expr/_core.py
+++ b/dask_expr/_core.py
@@ -225,7 +225,7 @@ class Expr:
 
         return {(self._name, i): self._task(i) for i in range(self.npartitions)}
 
-    def rewrite(self, kind: str):
+    def rewrite(self, kind: str, cache):
         """Rewrite an expression
 
         This leverages the ``._{kind}_down`` and ``._{kind}_up``
@@ -238,6 +238,9 @@ class Expr:
         changed:
             whether or not any change occured
         """
+        if self._name in cache:
+            return cache[self._name]
+
         expr = self
         down_name = f"_{kind}_down"
         up_name = f"_{kind}_up"
@@ -274,7 +277,8 @@ class Expr:
             changed = False
             for operand in expr.operands:
                 if isinstance(operand, Expr):
-                    new = operand.rewrite(kind=kind)
+                    new = operand.rewrite(kind=kind, cache=cache)
+                    cache[operand._name] = new
                     if new._name != operand._name:
                         changed = True
                 else:

--- a/dask_expr/_core.py
+++ b/dask_expr/_core.py
@@ -50,7 +50,6 @@ class Expr:
         assert not kwargs, kwargs
         inst = object.__new__(cls)
         inst.operands = [_unpack_collections(o) for o in operands] + [_branch_id]
-        inst._parameters = cls._parameters + ["_branch_id"]
         _name = inst._name
         if _name in Expr._instances:
             return Expr._instances[_name]
@@ -61,6 +60,10 @@ class Expr:
     @functools.cached_property
     def argument_operands(self):
         return self.operands[:-1]
+
+    @functools.cached_property
+    def _branch_id(self):
+        return self.operands[-1]
 
     def _tune_down(self):
         return None
@@ -159,7 +162,7 @@ class Expr:
     def operand(self, key):
         # Access an operand unambiguously
         # (e.g. if the key is reserved by a method/property)
-        return self.operands[self._parameters.index(key)]
+        return self.operands[type(self)._parameters.index(key)]
 
     def dependencies(self):
         # Dependencies are `Expr` operands only
@@ -440,10 +443,6 @@ class Expr:
     @property
     def _meta(self):
         raise NotImplementedError()
-
-    @functools.cached_property
-    def _branch_id(self):
-        return self.operands[-1]
 
     def __getattr__(self, key):
         try:

--- a/dask_expr/_cumulative.py
+++ b/dask_expr/_cumulative.py
@@ -47,7 +47,7 @@ class CumulativeBlockwise(Blockwise):
 
     @functools.cached_property
     def _args(self) -> list:
-        return self.operands[:-1]
+        return self.argument_operands[:-1]
 
 
 class TakeLast(Blockwise):

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2780,7 +2780,7 @@ def optimize(
     result = expr
     while True:
         if common_subplan_elimination:
-            out = result.rewrite("reuse")
+            out = result.rewrite("reuse", cache={})
         else:
             out = result
         out = out.simplify()
@@ -2791,13 +2791,13 @@ def optimize(
     result = out
 
     # Manipulate Expression to make it more efficient
-    result = result.rewrite(kind="tune")
+    result = result.rewrite(kind="tune", cache={})
 
     # Lower
     result = result.lower_completely()
 
     # Cull
-    result = result.rewrite(kind="cull")
+    result = result.rewrite(kind="cull", cache={})
 
     # Final graph-specific optimizations
     if fuse:

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -53,6 +53,7 @@ from pandas.errors import PerformanceWarning
 from tlz import merge_sorted, partition, unique
 
 from dask_expr import _core as core
+from dask_expr._core import BranchId
 from dask_expr._util import (
     _calc_maybe_new_divisions,
     _convert_to_list,
@@ -2719,9 +2720,11 @@ class _DelayedExpr(Expr):
     # TODO
     _parameters = ["obj"]
 
-    def __init__(self, obj):
+    def __init__(self, obj, _branch_id=None):
         self.obj = obj
-        self.operands = [obj]
+        if _branch_id is None:
+            _branch_id = BranchId(None)
+        self.operands = [obj, _branch_id]
 
     def __str__(self):
         return f"{type(self).__name__}({str(self.obj)})"

--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -106,7 +106,7 @@ class GroupByBase:
 
     @functools.cached_property
     def by(self):
-        return self.argument_operands[len(self._parameters) - 1 :]
+        return self.argument_operands[len(self._parameters) :]
 
     @functools.cached_property
     def levels(self):
@@ -738,7 +738,7 @@ class Mean(SingleAggregation):
                 self.operand(param)
                 if param not in ("chunk_kwargs", "aggregate_kwargs")
                 else {}
-                for param in self._parameters[:-1]
+                for param in self._parameters
             ],
             *self.by,
             self._branch_id,

--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -106,7 +106,7 @@ class GroupByBase:
 
     @functools.cached_property
     def by(self):
-        return self.operands[len(self._parameters) :]
+        return self.argument_operands[len(self._parameters) - 1 :]
 
     @functools.cached_property
     def levels(self):
@@ -738,9 +738,10 @@ class Mean(SingleAggregation):
                 self.operand(param)
                 if param not in ("chunk_kwargs", "aggregate_kwargs")
                 else {}
-                for param in self._parameters
+                for param in self._parameters[:-1]
             ],
             *self.by,
+            self._branch_id,
         )
         if is_dataframe_like(s._meta):
             c = c[s.columns]

--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -98,7 +98,7 @@ class Aggregate(Chunk):
 
     @functools.cached_property
     def aggregate_args(self):
-        return self.argument_operands[len(self._parameters) - 1 :]
+        return self.argument_operands[len(self._parameters) :]
 
     @staticmethod
     def _call_with_list_arg(func, *args, **kwargs):

--- a/dask_expr/_reductions.py
+++ b/dask_expr/_reductions.py
@@ -26,6 +26,7 @@ from dask.dataframe.core import (
 from dask.utils import M, apply, funcname
 
 from dask_expr._concat import Concat
+from dask_expr._core import BranchId
 from dask_expr._expr import (
     Blockwise,
     Expr,
@@ -97,7 +98,7 @@ class Aggregate(Chunk):
 
     @functools.cached_property
     def aggregate_args(self):
-        return self.operands[len(self._parameters) :]
+        return self.argument_operands[len(self._parameters) - 1 :]
 
     @staticmethod
     def _call_with_list_arg(func, *args, **kwargs):
@@ -506,6 +507,35 @@ class ApplyConcatApply(Expr):
             shuffle_method=getattr(self, "shuffle_method", None),
             ignore_index=getattr(self, "ignore_index", True),
         )
+
+    def _push_branch_id(self, parent):
+        return
+
+    def _simplify_down(self):
+        if self._branch_id.branch_id is not None:
+            return
+
+        seen = set()
+        stack = self.dependencies()
+        counter, found_io = 1, False
+
+        while stack:
+            node = stack.pop()
+
+            if node._name in seen:
+                continue
+            seen.add(node._name)
+
+            if isinstance(node, ApplyConcatApply):
+                counter += 1
+                continue
+            deps = node.dependencies()
+            if not deps:
+                found_io = True
+            stack.extend(deps)
+        if not found_io:
+            return
+        return type(self)(*self.operands[:-1], BranchId(counter))
 
 
 class Unique(ApplyConcatApply):

--- a/dask_expr/_str_accessor.py
+++ b/dask_expr/_str_accessor.py
@@ -128,7 +128,7 @@ class CatBlockwise(Blockwise):
 
     @property
     def _args(self) -> list:
-        return [self.frame] + self.argument_operands[len(self._parameters) - 1 :]
+        return [self.frame] + self.argument_operands[len(self._parameters) :]
 
     @staticmethod
     def operation(ser, *args, **kwargs):

--- a/dask_expr/_str_accessor.py
+++ b/dask_expr/_str_accessor.py
@@ -128,7 +128,7 @@ class CatBlockwise(Blockwise):
 
     @property
     def _args(self) -> list:
-        return [self.frame] + self.operands[len(self._parameters) :]
+        return [self.frame] + self.argument_operands[len(self._parameters) - 1 :]
 
     @staticmethod
     def operation(ser, *args, **kwargs):

--- a/dask_expr/io/_delayed.py
+++ b/dask_expr/io/_delayed.py
@@ -30,7 +30,7 @@ class FromDelayed(PartitionsFiltered, BlockwiseIO):
 
     @functools.cached_property
     def dfs(self):
-        return self.argument_operands[len(self._parameters) - 1 :]
+        return self.argument_operands[len(self._parameters) :]
 
     @functools.cached_property
     def _meta(self):

--- a/dask_expr/io/_delayed.py
+++ b/dask_expr/io/_delayed.py
@@ -30,7 +30,7 @@ class FromDelayed(PartitionsFiltered, BlockwiseIO):
 
     @functools.cached_property
     def dfs(self):
-        return self.operands[len(self._parameters) :]
+        return self.argument_operands[len(self._parameters) - 1 :]
 
     @functools.cached_property
     def _meta(self):

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -454,7 +454,7 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
     _absorb_projections = True
 
     def _tree_repr_argument_construction(self, i, op, header):
-        if self._parameters[i] == "_dataset_info_cache":
+        if i < len(self._parameters) and self._parameters[i] == "_dataset_info_cache":
             # Don't print this, very ugly
             return header
         return super()._tree_repr_argument_construction(i, op, header)

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -1924,9 +1924,7 @@ def test_assign_squash_together(df, pdf):
     pdf["a"] = 1
     pdf["b"] = 2
     assert_eq(df, pdf)
-    assert "Assign: a=1, b=2, ranchId(branch_id=0=" in [
-        line for line in result.expr._tree_repr_lines()
-    ]
+    assert "Assign: a=1, b=2" in [line for line in result.expr._tree_repr_lines()]
 
 
 def test_are_co_aligned(pdf, df):

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -942,7 +942,7 @@ def test_repr(df):
     s = (df["x"] + 1).sum(skipna=False).expr
     assert '["x"]' in str(s) or "['x']" in str(s)
     assert "+ 1" in str(s)
-    assert "sum(skipna=False)" in str(s)
+    assert "sum(skipna=False" in str(s)
 
 
 @xfail_gpu("combine_first not supported by cudf")
@@ -1924,7 +1924,9 @@ def test_assign_squash_together(df, pdf):
     pdf["a"] = 1
     pdf["b"] = 2
     assert_eq(df, pdf)
-    assert "Assign: a=1, b=2" in [line for line in result.expr._tree_repr_lines()]
+    assert "Assign: a=1, b=2, ranchId(branch_id=0=" in [
+        line for line in result.expr._tree_repr_lines()
+    ]
 
 
 def test_are_co_aligned(pdf, df):
@@ -2412,7 +2414,10 @@ def test_filter_optimize_condition():
 
 def test_scalar_repr(df):
     result = repr(df.size)
-    assert result == "<dask_expr.expr.Scalar: expr=df.size(), dtype=int64>"
+    assert (
+        result
+        == "<dask_expr.expr.Scalar: expr=df.size(_branch_id=BranchId(branch_id=0)), dtype=int64>"
+    )
 
 
 def test_reset_index_filter_pushdown(df):

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -2412,10 +2412,7 @@ def test_filter_optimize_condition():
 
 def test_scalar_repr(df):
     result = repr(df.size)
-    assert (
-        result
-        == "<dask_expr.expr.Scalar: expr=df.size(_branch_id=BranchId(branch_id=0)), dtype=int64>"
-    )
+    assert result == "<dask_expr.expr.Scalar: expr=df.size(), dtype=int64>"
 
 
 def test_reset_index_filter_pushdown(df):

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -34,7 +34,7 @@ def test_groupby_unsupported_by(pdf, df):
 @pytest.mark.parametrize("split_every", [None, 5])
 @pytest.mark.parametrize(
     "api",
-    ["mean", "min", "max", "prod", "first", "last", "var", "std", "idxmin"],
+    ["sum", "mean", "min", "max", "prod", "first", "last", "var", "std", "idxmin"],
 )
 @pytest.mark.parametrize(
     "numeric_only",
@@ -95,18 +95,19 @@ def test_groupby_numeric(pdf, df, api, numeric_only, split_every):
 
 def test_groupby_reduction_optimize(pdf, df):
     df = df.replace(1, 5)
-    agg = df.groupby(df.x).y.sum()
-    expected_query = df[["x", "y"]]
-    expected_query = expected_query.groupby(expected_query.x).y.sum()
-    assert agg.optimize()._name == expected_query.optimize()._name
-    expect = pdf.replace(1, 5).groupby(["x"]).y.sum()
-    assert_eq(agg, expect)
+    # agg = df.groupby(df.x).y.sum()
+    # expected_query = df[["x", "y"]]
+    # expected_query = expected_query.groupby(expected_query.x).y.sum()
+    # assert agg.optimize()._name == expected_query.optimize()._name
+    # expect = pdf.replace(1, 5).groupby(["x"]).y.sum()
+    # assert_eq(agg, expect)
 
     df2 = df[["y"]]
     agg = df2.groupby(df.x).y.sum()
     ops = [
         op for op in agg.expr.optimize(fuse=False).walk() if isinstance(op, FromPandas)
     ]
+    agg.simplify().pprint()
     assert len(ops) == 1
     assert ops[0].columns == ["x", "y"]
 

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -95,12 +95,12 @@ def test_groupby_numeric(pdf, df, api, numeric_only, split_every):
 
 def test_groupby_reduction_optimize(pdf, df):
     df = df.replace(1, 5)
-    # agg = df.groupby(df.x).y.sum()
-    # expected_query = df[["x", "y"]]
-    # expected_query = expected_query.groupby(expected_query.x).y.sum()
-    # assert agg.optimize()._name == expected_query.optimize()._name
-    # expect = pdf.replace(1, 5).groupby(["x"]).y.sum()
-    # assert_eq(agg, expect)
+    agg = df.groupby(df.x).y.sum()
+    expected_query = df[["x", "y"]]
+    expected_query = expected_query.groupby(expected_query.x).y.sum()
+    assert agg.optimize()._name == expected_query.optimize()._name
+    expect = pdf.replace(1, 5).groupby(["x"]).y.sum()
+    assert_eq(agg, expect)
 
     df2 = df[["y"]]
     agg = df2.groupby(df.x).y.sum()

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -34,7 +34,7 @@ def test_groupby_unsupported_by(pdf, df):
 @pytest.mark.parametrize("split_every", [None, 5])
 @pytest.mark.parametrize(
     "api",
-    ["sum", "mean", "min", "max", "prod", "first", "last", "var", "std", "idxmin"],
+    ["mean", "min", "max", "prod", "first", "last", "var", "std", "idxmin"],
 )
 @pytest.mark.parametrize(
     "numeric_only",

--- a/dask_expr/tests/test_reuse.py
+++ b/dask_expr/tests/test_reuse.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pytest
+
+from dask_expr import from_pandas
+from dask_expr.io import IO
+from dask_expr.tests._util import _backend_library, assert_eq
+
+# Set DataFrame backend for this module
+pd = _backend_library()
+
+
+@pytest.fixture
+def pdf():
+    pdf = pd.DataFrame({"x": range(100), "a": 1, "b": 1, "c": 1})
+    pdf["y"] = pdf.x // 7  # Not unique; duplicates span different partitions
+    yield pdf
+
+
+@pytest.fixture
+def df(pdf):
+    yield from_pandas(pdf, npartitions=10)
+
+
+def _check_io_nodes(expr, expected):
+    assert len(list(expr.find_operations(IO))) == expected
+
+
+def test_reuse_everything_scalar_and_series(df, pdf):
+    df["new"] = 1
+    df["new2"] = df["x"] + 1
+    df["new3"] = df.x[df.x > 1] + df.x[df.x > 2]
+
+    pdf["new"] = 1
+    pdf["new2"] = pdf["x"] + 1
+    pdf["new3"] = pdf.x[pdf.x > 1] + pdf.x[pdf.x > 2]
+    assert_eq(df, pdf)
+    _check_io_nodes(df.optimize(fuse=False), 1)
+
+
+def test_dont_reuse_reducer(df, pdf):
+    result = df.replace(1, 5)
+    result["new"] = result.x + result.y.sum()
+    expected = pdf.replace(1, 5)
+    expected["new"] = expected.x + expected.y.sum()
+    assert_eq(result, expected)
+    _check_io_nodes(result.optimize(fuse=False), 2)
+
+    result = df + df.sum()
+    expected = pdf + pdf.sum()
+    assert_eq(result, expected)
+    _check_io_nodes(result.optimize(fuse=False), 2)
+
+    result = df.replace(1, 5)
+    rhs_1 = result.x + result.y.sum()
+    rhs_2 = result.b + result.a.sum()
+    result["new"] = rhs_1
+    result["new2"] = rhs_2
+    expected = pdf.replace(1, 5)
+    expected["new"] = expected.x + expected.y.sum()
+    expected["new2"] = expected.b + expected.a.sum()
+    assert_eq(result, expected)
+    result.optimize(fuse=False).pprint()
+    _check_io_nodes(result.optimize(fuse=False), 2)
+
+    result = df.replace(1, 5)
+    result["new"] = result.x + result.y.sum()
+    result["new2"] = result.b + result.a.sum()
+    expected = pdf.replace(1, 5)
+    expected["new"] = expected.x + expected.y.sum()
+    expected["new2"] = expected.b + expected.a.sum()
+    assert_eq(result, expected)
+    result.optimize(fuse=False).pprint()
+    _check_io_nodes(result.optimize(fuse=False), 3)
+
+    result = df.replace(1, 5)
+    result["new"] = result.x + result.sum().dropna().prod()
+    expected = pdf.replace(1, 5)
+    expected["new"] = expected.x + expected.sum().dropna().prod()
+    assert_eq(result, expected)
+    result.optimize(fuse=False).pprint()
+    _check_io_nodes(result.optimize(fuse=False), 2)

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -137,7 +137,7 @@ def test_shuffle_column_projection(df):
 
 
 def test_shuffle_reductions(df):
-    assert df.shuffle("x").sum().simplify()._name == df.sum()._name
+    assert df.shuffle("x").sum().simplify()._name == df.sum().simplify()._name
 
 
 @pytest.mark.xfail(reason="Shuffle can't see the reduction through the Projection")
@@ -716,7 +716,7 @@ def test_sort_values_avoid_overeager_filter_pushdown(meth):
     pdf1 = pd.DataFrame({"a": [4, 2, 3], "b": [1, 2, 3]})
     df = from_pandas(pdf1, npartitions=2)
     df = getattr(df, meth)("a")
-    df = df[df.b > 2] + df.b.sum()
+    df = df[df.b > 2] + df[df.b > 1]
     result = df.simplify()
     assert isinstance(result.expr.left, Filter)
     assert isinstance(result.expr.left.frame, BaseSetIndexSortValues)

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -137,7 +137,7 @@ def test_shuffle_column_projection(df):
 
 
 def test_shuffle_reductions(df):
-    assert df.shuffle("x").sum().simplify()._name == df.sum().simplify()._name
+    assert df.shuffle("x").sum().optimize()._name == df.sum().optimize()._name
 
 
 @pytest.mark.xfail(reason="Shuffle can't see the reduction through the Projection")
@@ -264,7 +264,7 @@ def test_set_index_repartition(df, pdf):
     assert_eq(result, pdf.set_index("x"))
 
 
-def test_set_index_simplify(df, pdf):
+def test_set_index_optimize(df, pdf):
     q = df.set_index("x")["y"].optimize(fuse=False)
     expected = df[["x", "y"]].set_index("x")["y"].optimize(fuse=False)
     assert q._name == expected._name
@@ -697,18 +697,21 @@ def test_shuffle_filter_pushdown(pdf, meth):
     result = result[result.x > 5.0]
     expected = getattr(df[df.x > 5.0], meth)("x")
     assert result.simplify()._name == expected._name
+    assert result.optimize()._name == expected.optimize()._name
 
     result = getattr(df, meth)("x")
     result = result[result.x > 5.0][["x", "y"]]
     expected = df[["x", "y"]]
     expected = getattr(expected[expected.x > 5.0], meth)("x")
     assert result.simplify()._name == expected.simplify()._name
+    assert result.optimize()._name == expected.optimize()._name
 
     result = getattr(df, meth)("x")[["x", "y"]]
     result = result[result.x > 5.0]
     expected = df[["x", "y"]]
     expected = getattr(expected[expected.x > 5.0], meth)("x")
     assert result.simplify()._name == expected.simplify()._name
+    assert result.optimize()._name == expected.optimize()._name
 
 
 @pytest.mark.parametrize("meth", ["set_index", "sort_values"])
@@ -729,15 +732,18 @@ def test_set_index_filter_pushdown():
     result = result[result.y == 1]
     expected = df[df.y == 1].set_index("x")
     assert result.simplify()._name == expected._name
+    assert result.optimize()._name == expected.optimize()._name
 
     result = df.set_index("x")
     result = result[result.y == 1][["y"]]
     expected = df[["x", "y"]]
     expected = expected[expected.y == 1].set_index("x")
     assert result.simplify()._name == expected.simplify()._name
+    assert result.optimize()._name == expected.optimize()._name
 
     result = df.set_index("x")[["y"]]
     result = result[result.y == 1]
     expected = df[["x", "y"]]
     expected = expected[expected.y == 1].set_index("x")
     assert result.simplify()._name == expected.simplify()._name
+    assert result.optimize()._name == expected.optimize()._name


### PR DESCRIPTION
ref #854

Couple of thoughts here:

- enabling / disabling reuse of branches seems like a completely different thing compared to what we do in simplify, so it felt wrong adding it in here and we would need more special casing on top of it. I want an easy way to opt out of this, so having a more central approach seems a lot better

- branch_id needs to be available on every expression, so that we can move this around freely without worrying if the expression supports it.

- it has to be available in __new__, because it influences how the expression tokenises. 

- I decided to bubble the expression step by step but not keep it on intermediate layers (e.g. non Reductions and non IO layers). We would have to consider the branch_id in every lower and simplify operation to avoid dropping it in between, which introduces a lot of uncertainty and mental lode which didn't seem to be worth the effort. The step by step approach gives us more flexibility how we handle other Expressions that can consume the branch_id (thinking about merges and shuffles at the moment)


This is not ready to merge, it needs more tests and support for merges and shuffles at least, maybe more. But it does what it's supposed to now