### PR TITLE
Simplify again after lowering

### DIFF
--- a/dask_expr/_core.py
+++ b/dask_expr/_core.py
@@ -53,12 +53,6 @@ class Expr:
     def _tune_up(self, parent):
         return None
 
-    def _cull_down(self):
-        return None
-
-    def _cull_up(self, parent):
-        return None
-
     def __str__(self):
         s = ", ".join(
             str(param) + "=" + str(operand)

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -3485,16 +3485,19 @@ def determine_column_projection(expr, parent, dependents, additional_columns=Non
 
 def _sort_mixed(values):
     """order ints before strings before nulls in 1d arrays"""
-    str_pos = np.array([isinstance(x, (str, tuple)) for x in values], dtype=bool)
+    str_pos = np.array([isinstance(x, str) for x in values], dtype=bool)
+    tuple_pos = np.array([isinstance(x, str) for x in values], dtype=bool)
     null_pos = np.array([pd.isna(x) for x in values], dtype=bool)
-    num_pos = ~str_pos & ~null_pos
+    num_pos = ~str_pos & ~null_pos & ~tuple_pos
     str_argsort = np.argsort(values[str_pos])
+    tuple_argsort = np.argsort(values[tuple_pos])
     num_argsort = np.argsort(values[num_pos])
     # convert boolean arrays to positional indices, then order by underlying values
     str_locs = str_pos.nonzero()[0].take(str_argsort)
+    tuple_locs = str_pos.nonzero()[0].take(tuple_argsort)
     num_locs = num_pos.nonzero()[0].take(num_argsort)
     null_locs = null_pos.nonzero()[0]
-    locs = np.concatenate([num_locs, str_locs, null_locs])
+    locs = np.concatenate([num_locs, str_locs, tuple_locs, null_locs])
     return values.take(locs)
 
 

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -3485,7 +3485,7 @@ def determine_column_projection(expr, parent, dependents, additional_columns=Non
 
 def _sort_mixed(values):
     """order ints before strings before nulls in 1d arrays"""
-    str_pos = np.array([isinstance(x, str) for x in values], dtype=bool)
+    str_pos = np.array([isinstance(x, (str, tuple)) for x in values], dtype=bool)
     null_pos = np.array([pd.isna(x) for x in values], dtype=bool)
     num_pos = ~str_pos & ~null_pos
     str_argsort = np.argsort(values[str_pos])

--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -3486,7 +3486,7 @@ def determine_column_projection(expr, parent, dependents, additional_columns=Non
 def _sort_mixed(values):
     """order ints before strings before nulls in 1d arrays"""
     str_pos = np.array([isinstance(x, str) for x in values], dtype=bool)
-    tuple_pos = np.array([isinstance(x, str) for x in values], dtype=bool)
+    tuple_pos = np.array([isinstance(x, tuple) for x in values], dtype=bool)
     null_pos = np.array([pd.isna(x) for x in values], dtype=bool)
     num_pos = ~str_pos & ~null_pos & ~tuple_pos
     str_argsort = np.argsort(values[str_pos])
@@ -3494,7 +3494,7 @@ def _sort_mixed(values):
     num_argsort = np.argsort(values[num_pos])
     # convert boolean arrays to positional indices, then order by underlying values
     str_locs = str_pos.nonzero()[0].take(str_argsort)
-    tuple_locs = str_pos.nonzero()[0].take(tuple_argsort)
+    tuple_locs = tuple_pos.nonzero()[0].take(tuple_argsort)
     num_locs = num_pos.nonzero()[0].take(num_argsort)
     null_locs = null_pos.nonzero()[0]
     locs = np.concatenate([num_locs, str_locs, tuple_locs, null_locs])

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -257,8 +257,8 @@ def test_filter_pushdown_reducer_in_predicate():
     df = from_pandas(pdf, npartitions=2)
     df = df[df.b.isin(["a", "b"])]
     avg = df["a"].mean()
-
     result = df[df["a"] > avg]["a"]
+
     pdf = pdf[pdf.b.isin(["a", "b"])]
     avg = pdf["a"].mean()
     expected = pdf[pdf["a"] > avg]["a"]

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -121,6 +121,12 @@ def test_groupby_reduction_optimize(pdf, df):
     assert_eq(agg, pdf.replace(1, 5).groupby(pdf.replace(1, 5).x).y.apply(lambda x: x))
 
 
+def test_std_columns_int():
+    df = pd.DataFrame({0: [5], 1: [5]})
+    ddf = from_pandas(df, npartitions=2)
+    assert_eq(ddf.groupby(ddf[0]).std(), df.groupby(df[0].copy()).std())
+
+
 @pytest.mark.parametrize(
     "func",
     [


### PR DESCRIPTION
We removed this when we still had combine_similar, because simplifying again would have screwed over everything. This is not a concern anymore and we only needed 2 small changes to make this work again