### PR TITLE
Fix merge predicate pushdowns with weird predicates

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1172,6 +1172,7 @@ class RenameFrame(Elemwise):
             reverse_mapping = {val: key for key, val in self.operand("columns").items()}
 
             columns = determine_column_projection(self, parent, dependents)
+            columns = _convert_to_list(columns)
             columns = [
                 reverse_mapping[col] if col in reverse_mapping else col
                 for col in columns

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -26,6 +26,8 @@ from dask_expr._expr import (  # noqa: F401
     PartitionsFiltered,
     Projection,
     Unaryop,
+    _DelayedExpr,
+    are_co_aligned,
     determine_column_projection,
     is_filter_pushdown_available,
 )
@@ -107,6 +109,45 @@ class Merge(Expr):
                 return False
             return True
         return False
+
+    def _predicate_columns(self, predicate):
+        if isinstance(predicate, (Projection, Unaryop, Isin)):
+            return self._walk_predicates(predicate)
+        elif isinstance(predicate, Binop):
+            if isinstance(predicate, And):
+                return None
+
+            if not isinstance(predicate.right, Expr):
+                return self._walk_predicates(predicate.left)
+            elif isinstance(predicate.right, Elemwise):
+                return self._walk_predicates(predicate)
+            else:
+                return None
+        else:
+            # Unsupported predicate type
+            return None
+
+    def _walk_predicates(self, predicate):
+        predicate_columns = set()
+        stack = [predicate]
+        seen = set()
+        while stack:
+            e = stack.pop()
+            if self._name == e._name:
+                continue
+
+            if e._name in seen:
+                continue
+            seen.add(e._name)
+
+            if isinstance(e, _DelayedExpr):
+                continue
+
+            dependencies = e.dependencies()
+            stack.extend(dependencies)
+            if any(d._name == self._name for d in dependencies):
+                predicate_columns.update(e.columns)
+        return predicate_columns
 
     def __str__(self):
         return f"Merge({self._name[-7:]})"
@@ -387,23 +428,6 @@ class Merge(Expr):
 
         # Blockwise merge
         return BlockwiseMerge(left, right, **self.kwargs)
-
-    def _predicate_columns(self, predicate):
-        if isinstance(predicate, (Projection, Unaryop, Isin)):
-            return set(predicate.columns)
-        elif isinstance(predicate, Binop):
-            if isinstance(predicate, And):
-                return None
-
-            if not isinstance(predicate.right, Expr):
-                return set(predicate.left.columns)
-            elif isinstance(predicate.right, Elemwise):
-                return set(predicate.left.columns) | set(predicate.right.columns)
-            else:
-                return None
-        else:
-            # Unsupported predicate type
-            return None
 
     def _simplify_up(self, parent, dependents):
         if isinstance(parent, Filter):

--- a/dask_expr/_merge.py
+++ b/dask_expr/_merge.py
@@ -112,22 +112,22 @@ class Merge(Expr):
 
     def _predicate_columns(self, predicate):
         if isinstance(predicate, (Projection, Unaryop, Isin)):
-            return self._walk_predicates(predicate)
+            return self._get_original_predicate_columns(predicate)
         elif isinstance(predicate, Binop):
             if isinstance(predicate, And):
                 return None
 
             if not isinstance(predicate.right, Expr):
-                return self._walk_predicates(predicate.left)
+                return self._get_original_predicate_columns(predicate.left)
             elif isinstance(predicate.right, Elemwise):
-                return self._walk_predicates(predicate)
+                return self._get_original_predicate_columns(predicate)
             else:
                 return None
         else:
             # Unsupported predicate type
             return None
 
-    def _walk_predicates(self, predicate):
+    def _get_original_predicate_columns(self, predicate):
         predicate_columns = set()
         stack = [predicate]
         seen = set()

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -1927,6 +1927,12 @@ def test_assign_squash_together(df, pdf):
     assert "Assign: a=1, b=2" in [line for line in result.expr._tree_repr_lines()]
 
 
+def test_rename_series_reduction(pdf, df):
+    result = df[["x"]].rename(columns={"x": "a"})["a"]
+    expected = pdf[["x"]].rename(columns={"x": "a"})["a"]
+    assert_eq(result, expected)
+
+
 def test_are_co_aligned(pdf, df):
     df2 = df.reset_index()
     assert are_co_aligned(df.expr, df2.expr)


### PR DESCRIPTION
I thought a little about how we do predicate pushdowns and stumbled upon this, we currently don't cover weird predicates very well, we have to walk the predicate until we arrive at the merge to determine from which side they are from