### PR TITLE
Revert "Use Aggregation from dask/dask"

### DIFF
--- a/dask_expr/__init__.py
+++ b/dask_expr/__init__.py
@@ -2,6 +2,7 @@ from dask_expr import _version, datasets
 from dask_expr._collection import *
 from dask_expr._dispatch import get_collection_type
 from dask_expr._dummies import get_dummies
+from dask_expr._groupby import Aggregation
 from dask_expr.io._delayed import from_delayed
 from dask_expr.io.bag import to_bag
 from dask_expr.io.csv import to_csv

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -4,10 +4,9 @@ from collections import OrderedDict
 import dask
 import numpy as np
 import pytest
-from dask.dataframe import Aggregation
 
 from dask_expr import from_pandas
-from dask_expr._groupby import GroupByUDFBlockwise
+from dask_expr._groupby import Aggregation, GroupByUDFBlockwise
 from dask_expr._reductions import TreeReduce
 from dask_expr._shuffle import Shuffle, divisions_lru
 from dask_expr.io import FromPandas


### PR DESCRIPTION
Reverts dask-contrib/dask-expr#895

Should revert this so that we can release on top of the current released dask version