### PR TITLE
P2P shuffle drops partitioning column early

### DIFF
--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -539,6 +539,10 @@ class DiskShuffle(SimpleShuffle):
 class P2PShuffle(SimpleShuffle):
     """P2P worker-based shuffle implementation"""
 
+    @functools.cached_property
+    def _meta(self):
+        return self.frame._meta.drop(columns=self.partitioning_index)
+
     def _layer(self):
         from distributed.shuffle._shuffle import (
             ShuffleId,
@@ -567,6 +571,7 @@ class P2PShuffle(SimpleShuffle):
                 self.partitioning_index,
                 self.frame._meta,
                 set(parts_out),
+                True,
                 True,
             )
 


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/8530

Sibling to https://github.com/dask/distributed/pull/8531.

I don't like that the column gets assigned outside of the shuffle but dropped inside the shuffle. We may want to restructure this in a follow-up.