### PR TITLE
Implement more efficient GroupBy.mean

### DIFF
--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -775,8 +775,8 @@ def _mean_chunk(df, *by, observed=None, dropna=None):
         df = df.to_frame()
 
     g = _groupby_raise_unaligned(df, by=by, observed=observed, dropna=dropna)
-    x = g.sum()
-    n = g.count().rename(columns=lambda c: c + "-count")
+    x = g.sum(numeric_only=True)
+    n = g[x.columns].count().rename(columns=lambda c: c + "-count")
     return concat([x, n], axis=1)
 
 

--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -1683,8 +1683,8 @@ class GroupBy:
         ):
             if len(result.columns) < 1:
                 raise NotImplementedError(
-                    "Cannot call `SeriesGroupBy.var` on the key column. "
-                    "Please use `aggregate` if you really need to do this."
+                    "Cannot call `SeriesGroupBy.var` or `SeriesGroupBy.mean` on the key "
+                    "column. Please use `aggregate` if you really need to do this."
                 )
             result = result[result.columns[0]]
         return result

--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -776,7 +776,7 @@ def _mean_chunk(df, *by, observed=None, dropna=None):
 
     g = _groupby_raise_unaligned(df, by=by, observed=observed, dropna=dropna)
     x = g.sum()
-    n = g.count().rename(columns=lambda c: (c, "-count"))
+    n = g.count().rename(columns=lambda c: c + "-count")
     return concat([x, n], axis=1)
 
 
@@ -819,7 +819,10 @@ class Mean(GroupByReduction):
     def _divisions(self):
         if self.sort:
             return (None, None)
-        return (None,) * (self.split_out + 1)
+        split_out = self.split_out
+        if split_out is True:
+            split_out = self.frame.npartitions
+        return (None,) * (split_out + 1)
 
     def _simplify_up(self, parent, dependents):
         return groupby_projection(self, parent, dependents)


### PR DESCRIPTION
This actually made a bigger difference than expected, it cuts query 17 from 5 minutes to 3:20, shuffling twice is just expensive

I will reactor the layout a little bit in a follow-up, but didn't want to touch too many things at once