### PR TITLE
Speedup init of `ReadParquetPyarrowFS`

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -2867,7 +2867,7 @@ def are_co_aligned(*exprs, allow_broadcast=True):
     ancestors = [set(non_blockwise_ancestors(e)) for e in exprs]
     unique_ancestors = {
         # Account for column projection within IO expressions
-        _tokenize_partial(item, ["columns", "_series"])
+        _tokenize_partial(item, ["columns", "_series", "_dataset_info_cache"])
         for item in flatten(ancestors, container=set)
     }
     # Don't check divisions or npartitions at all

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -655,7 +655,7 @@ class ReadParquetPyarrowFS(ReadParquet):
                 for finfo in self.fs.get_file_info(dataset_selector)
                 if finfo.type == pa.fs.FileType.File
             ]
-        except NotADirectoryError:
+        except (NotADirectoryError, FileNotFoundError):
             all_files = [self.fs.get_file_info(path_normalized)]
         # TODO: At this point we could verify if we're dealing with a very
         # inhomogeneous datasets already without reading any further data


### PR DESCRIPTION
This includes a couple of fixes to the `ReadParquetPyarrowFS` expr that speed up the initial kick off significantly. On the TPCH 1000 scale datasets for Q1 creating the query and optimizing it initially took 10-11s on my machine (with me sitting in europe and the dataset in us-east-2). With these fixes, we're down to 1-2s which is on par with the fsspec implementation.