### PR TITLE
Wrap fragments

### DIFF
--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -87,9 +87,6 @@ NONE_LABEL = "__null_dask_index__"
 _CACHED_PLAN_SIZE = 10
 _cached_plan = {}
 
-import pickle
-import weakref
-
 
 class FragmentWrapper:
     _filesystems = weakref.WeakValueDictionary()


### PR DESCRIPTION
This is not my preferred way of doing things but this effectively bypasses https://github.com/apache/arrow/issues/40279 and delays the initialization cost of the filesystem to the workers. This is only necessarily because we no longer have the "don't deserialize on scheduler" mechanics (at least not properly). The most important part is the delay of the filesystem deserialization. However, storing this as a bytestring comes at a cost since pickle can't seem to deduplicate this any longer such that the overall size of the serialized graph is larger. 

I still have to run a few more tests to see if this is all really worth it.