### PR TITLE
DNM Use pyarrow to concat

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -4653,10 +4653,6 @@ def read_parquet(
             raise ValueError(
                 "pyarrow>=15.0.0 is required to use the pyarrow filesystem."
             )
-        if calculate_divisions:
-            raise NotImplementedError(
-                "calculate_divisions is not supported when using the pyarrow filesystem."
-            )
         if metadata_task_size is not None:
             raise NotImplementedError(
                 "metadata_task_size is not supported when using the pyarrow filesystem."
@@ -4689,6 +4685,7 @@ def read_parquet(
                 filters=filters,
                 categories=categories,
                 index=index,
+                calculate_divisions=calculate_divisions,
                 storage_options=storage_options,
                 filesystem=filesystem,
                 ignore_metadata_file=ignore_metadata_file,

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -6,7 +6,7 @@ import operator
 import warnings
 from abc import abstractmethod
 from collections import defaultdict
-from functools import cached_property
+from functools import cached_property, partial
 
 import dask
 import pandas as pd
@@ -16,6 +16,7 @@ import pyarrow.fs as pa_fs
 import pyarrow.parquet as pq
 import tlz as toolz
 from dask.base import normalize_token, tokenize
+from dask.core import flatten
 from dask.dataframe.io.parquet.core import (
     ParquetFunctionWrapper,
     ToParquetFunctionWrapper,
@@ -63,6 +64,9 @@ def _tokenize_fileinfo(fileinfo):
         fileinfo.mtime_ns,
         fileinfo.size,
     )
+
+
+_STATS_CACHE = {}
 
 
 PYARROW_NULLABLE_DTYPE_MAPPING = {
@@ -592,7 +596,9 @@ class ReadParquetPyarrowFS(ReadParquet):
         "storage_options",
         "filesystem",
         "ignore_metadata_file",
+        "calculate_divisions",
         "kwargs",
+        "_statistics",
         "_partitions",
         "_series",
         "_dataset_info_cache",
@@ -605,7 +611,10 @@ class ReadParquetPyarrowFS(ReadParquet):
         "storage_options": None,
         "filesystem": None,
         "ignore_metadata_file": True,
+        "calculate_divisions": False,
+        "statistics": None,
         "kwargs": None,
+        "_statistics": None,
         "_partitions": None,
         "_series": False,
         "_dataset_info_cache": None,
@@ -630,6 +639,54 @@ class ReadParquetPyarrowFS(ReadParquet):
                 region = {} if "region" in storage_options else {"region": fs.region}
                 fs = type(fs)(**region, **storage_options)
             return fs
+
+    def _collect_statistics_plan(self):
+        # if _MAYBE_DIVISIONS_USEFUL.get():
+        # TODO: Consider just sampling. I don't think we'll need the entire
+        # metadat for everything
+        # TODO: I think we should cache these on a per-file basis
+        @dask.delayed
+        def _gather_statistics(frags):
+            def _collect_statistics(token_fragment):
+                # TODO: Consider cutting down the dict to safe memory. Very
+                # primitive files already store ~10KB
+                return token_fragment[1], _extract_stats(
+                    token_fragment[1].metadata.to_dict()
+                )
+
+            from concurrent.futures import ThreadPoolExecutor
+
+            with ThreadPoolExecutor() as tpe:
+                return list(tpe.map(_collect_statistics, frags))
+
+        to_collect = []
+        for finfo, frag in zip(
+            self._dataset_info["all_files"], self.fragments_unsorted
+        ):
+            if (token := tokenize(finfo)) not in _STATS_CACHE:
+                to_collect.append((token, frag))
+        # TODO: Should we use delayed or self.map_partitions?
+        return [
+            _gather_statistics(batch)
+            for batch in toolz.itertoolz.partition_all(20, to_collect)
+        ]
+
+    @cached_property
+    def raw_statistics(self):
+        token_stats = dask.compute(self._collect_statistics_plan())
+        for token, stats in token_stats:
+            _STATS_CACHE[token] = stats
+        return [
+            _STATS_CACHE[tokenize(finfo)] for finfo in self._dataset_info["all_files"]
+        ]
+
+    @cached_property
+    def aggregated_statistics(self):
+        return _aggregate_statistics(self.raw_statistics)
+
+    def set_statistics(self, statistics):
+        statistics = flatten(statistics)
+        return self.substitute_parameters({"_statistics": statistics})
 
     @cached_property
     def _dataset_info(self):
@@ -701,25 +758,53 @@ class ReadParquetPyarrowFS(ReadParquet):
         ] = dataset_info
         return dataset_info
 
+    @cached_property
+    def _division_from_stats(self):
+        """If enabled, compute the divisions from the collected statistics.
+        If divisions are possible to set, the second argument will be the
+        argsort of the fragments such that the divisions are correct.
+
+        Returns
+        -------
+        divisions
+        argsort
+        """
+        if self.calculate_divisions and self.index is not None:
+            index_name = self.index.name
+            return _divisions_from_statistics(self.aggregated_statistics, index_name)
+        return tuple([None] * (len(self.fragments_unsorted) + 1)), None
+
+    def _fragment_sort_index(self):
+        return self._division_from_stats[1]
+
     def _divisions(self):
-        return tuple([None] * (len(self.fragments) + 1))
+        return self._division_from_stats[0]
 
     @property
     def fragments(self):
+        if self._fragment_sort_index() is not None:
+            return self.fragments_unsorted[self._fragment_sort_index()].to_list()
+        return self.fragments_unsorted.to_list()
+
+    @property
+    def fragments_unsorted(self):
         if self.filters is not None:
             if self._dataset_info["using_metadata_file"]:
                 ds = self._dataset_info["dataset"]
             else:
                 ds = self._dataset_info["dataset"]._dataset
             return list(ds.get_fragments(filter=pq.filters_to_expression(self.filters)))
-        return self._dataset_info["fragments"]
+        return pd.Series(self._dataset_info["fragments"])
 
     @staticmethod
-    def _fragment_to_pandas(fragment, columns, filters, schema):
+    def _fragment_to_pandas(fragment, columns, filters, schema, index_name):
         from dask.utils import parse_bytes
 
         if isinstance(filters, list):
             filters = pq.filters_to_expression(filters)
+        if index_name is not None and columns is not None and index_name not in columns:
+            columns = columns.copy()
+            columns.append(index_name)
         # TODO: There should be a way for users to define the type mapper
         table = fragment.to_table(
             schema=schema,
@@ -749,7 +834,10 @@ class ReadParquetPyarrowFS(ReadParquet):
             types_mapper=_determine_type_mapper(),
             use_threads=False,
             self_destruct=True,
+            ignore_metadata=True,
         )
+        if index_name is not None:
+            df = df.set_index(index_name)
         return df
 
     def _filtered_task(self, index: int):
@@ -759,6 +847,7 @@ class ReadParquetPyarrowFS(ReadParquet):
             self.columns,
             self.filters,
             self._dataset_info["schema"],
+            self.index.name if self.index is not None else None,
         )
 
 
@@ -1338,3 +1427,138 @@ def _normalize_and_strip_protocol(path):
             break
     path = path.rstrip("/")
     return path
+
+
+def _divisions_from_statistics(aggregated_stats, index_name):
+    col_ix = -1
+    peak_rg = aggregated_stats[0]
+    for ix, col in enumerate(peak_rg["columns"]):
+        if col["path_in_schema"] == index_name:
+            col_ix = ix
+            break
+    else:
+        raise ValueError(f"Index column {index_name} not found in statistics")
+    last_max = None
+    minmax = []
+    for file_stats in aggregated_stats:
+        file_min = file_stats["columns"][col_ix]["statistics"]["min"]
+        file_max = file_stats["columns"][col_ix]["statistics"]["max"]
+
+        minmax.append((file_min, file_max))
+    divisions = []
+    minmax = pd.Series(minmax)
+
+    argsort = minmax.argsort()
+    sorted_minmax = minmax[argsort]
+    if not sorted_minmax.is_monotonic_increasing:
+        return tuple([None] * (len(aggregated_stats) + 1)), None
+    for file_min, file_max in sorted_minmax:
+        divisions.append(file_min)
+        last_max = file_max
+    divisions.append(last_max)
+    return tuple(divisions), argsort
+
+
+def _extract_stats(original):
+    """Take the raw file statistics as returned by pyarrow (as a dict) and
+    filter it to what we care about. The full stats are a bit too verbose and we
+    don't need all of it."""
+    # TODO: dicts are pretty memory inefficient. Move to dataclass?
+    file_level_stats = ["num_rows", "num_row_groups", "serialized_size"]
+    rg_stats = [
+        "num_rows",
+        "total_byte_size",
+        "sorting_columns",
+    ]
+    col_meta = [
+        "num_values",
+        "total_compressed_size",
+        "total_uncompressed_size",
+        "path_in_schema",
+    ]
+    col_stats = [
+        "min",
+        "max",
+        "null_count",
+        "num_values",
+        "distinct_count",
+    ]
+
+    out = {}
+    for name in file_level_stats:
+        out[name] = original[name]
+    out["row_groups"] = rgs = []
+    for rg in original["row_groups"]:
+        rg_out = {}
+        rgs.append(rg_out)
+        for name in rg_stats:
+            rg_out[name] = rg[name]
+        rg_out["columns"] = []
+        for col in rg["columns"]:
+            col_out = {}
+            rg_out["columns"].append(col_out)
+            for name in col_meta:
+                col_out[name] = col[name]
+            col_out["statistics"] = {}
+            for name in col_stats:
+                col_out["statistics"][name] = col["statistics"][name]
+
+    return out
+
+
+def _aggregate_statistics(stats):
+    """Aggregate RG information to file level."""
+
+    def _agg_dicts(dicts, agg_funcs):
+        result = {}
+        for d in dicts:
+            for k, v in d.items():
+                if k not in result:
+                    result[k] = [v]
+                else:
+                    result[k].append(v)
+        result2 = {}
+        for k, v in result.items():
+            agg = agg_funcs.get(k)
+            if agg:
+                result2[k] = agg(v)
+        return result2
+
+    def _aggregate_columns(cols):
+        agg_stats = {
+            "min": min,
+            "max": max,
+        }
+        agg_cols = {
+            "total_compressed_size": sum,
+            "total_uncompressed_size": sum,
+            "statistics": partial(_agg_dicts, agg_funcs=agg_stats),
+            "path_in_schema": lambda x: set(x).pop(),
+        }
+        combine = []
+        i = 0
+        while True:
+            inner = []
+            combine.append(inner)
+            try:
+                for col in cols:
+                    inner.append(col[i])
+            except IndexError:
+                combine.pop()
+                break
+            i += 1
+        return [_agg_dicts(c, agg_cols) for c in combine]
+
+    agg_func = {
+        "num_rows": sum,
+        "total_byte_size": sum,
+        "columns": _aggregate_columns,
+        "num_rows": sum,
+    }
+    aggregated_stats = []
+    for file_stat in stats:
+        file_stat = file_stat.copy()
+        aggregated_stats.append(file_stat)
+
+        file_stat.update(_agg_dicts(file_stat.pop("row_groups"), agg_func))
+    return aggregated_stats

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -932,6 +932,20 @@ class ReadParquetPyarrowFS(ReadParquet):
             self.index.name if self.index is not None else None,
         )
 
+    @property
+    def _fusion_compression_factor(self):
+        if self.operand("columns") is None:
+            return 1
+        approx_stats = self.approx_statistics()
+        total_uncompressed = 0
+        for col in approx_stats["columns"]:
+            total_uncompressed += col["total_uncompressed_size"]
+        after_projection = 0
+        for col in self.operands("columns"):
+            after_projection += col["total_uncompressed_size"]
+
+        return max(after_projection / total_uncompressed, 0.001)
+
 
 class ReadParquetFSSpec(ReadParquet):
     """Read a parquet dataset"""

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -640,10 +640,9 @@ class ReadParquetPyarrowFS(ReadParquet):
             return fs
 
     def _collect_statistics_plan(self):
-        # if _MAYBE_DIVISIONS_USEFUL.get():
+        # TODO: Fails for metadata file path
         # TODO: Consider just sampling. I don't think we'll need the entire
         # metadat for everything
-        # TODO: I think we should cache these on a per-file basis
         @dask.delayed
         def _gather_statistics(frags):
             def _collect_statistics(token_fragment):
@@ -735,7 +734,8 @@ class ReadParquetPyarrowFS(ReadParquet):
                     filesystem=self.fs,
                 )
                 dataset_info["using_metadata_file"] = True
-                dataset_info["fragments"] = dataset.get_fragments()
+                dataset_info["fragments"] = list(dataset.get_fragments())
+
         if checksum is None:
             checksum = tokenize(all_files)
         dataset_info["checksum"] = checksum
@@ -752,6 +752,7 @@ class ReadParquetPyarrowFS(ReadParquet):
             )
             dataset_info["using_metadata_file"] = False
             dataset_info["fragments"] = dataset.fragments
+            dataset_info["all_files"] = all_files
 
         dataset_info["dataset"] = dataset
         dataset_info["schema"] = dataset.schema

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -745,7 +745,7 @@ class ReadParquetPyarrowFS(ReadParquet):
 
     @cached_property
     def raw_statistics(self):
-        self.load_all_statistics()
+        self.load_statistics()
         return [
             _STATS_CACHE[tokenize(finfo)] for finfo in self._dataset_info["all_files"]
         ]
@@ -938,11 +938,12 @@ class ReadParquetPyarrowFS(ReadParquet):
             return 1
         approx_stats = self.approx_statistics()
         total_uncompressed = 0
+        after_projection = 0
+        col_op = self.operand("columns")
         for col in approx_stats["columns"]:
             total_uncompressed += col["total_uncompressed_size"]
-        after_projection = 0
-        for col in self.operands("columns"):
-            after_projection += col["total_uncompressed_size"]
+            if col["path_in_schema"] in col_op:
+                after_projection += col["total_uncompressed_size"]
 
         return max(after_projection / total_uncompressed, 0.001)
 

--- a/dask_expr/io/tests/test_parquet.py
+++ b/dask_expr/io/tests/test_parquet.py
@@ -24,8 +24,17 @@ def parquet_file(tmpdir):
     return _make_file(tmpdir)
 
 
-def test_parquet_len(tmpdir):
-    df = read_parquet(_make_file(tmpdir))
+@pytest.fixture(params=["arrow", "fsspec"])
+def filesystem(request):
+    return request.param
+    if request.param == "arrow":
+        return fs.LocalFileSystem()
+    else:
+        return None  # fsspec.filesystem("file")
+
+
+def test_parquet_len(tmpdir, filesystem):
+    df = read_parquet(_make_file(tmpdir), filesystem=filesystem)
     pdf = df.compute()
 
     assert len(df[df.a > 5]) == len(pdf[pdf.a > 5])

--- a/dask_expr/io/tests/test_parquet.py
+++ b/dask_expr/io/tests/test_parquet.py
@@ -316,3 +316,9 @@ def test_columns_index(tmpdir):
         ddf.clear_divisions(),
         check_divisions=True,
     )
+
+
+def test_repr_doesnt_trigger_stats(tmpdir):
+    fn = _make_file(tmpdir)
+    df = read_parquet(fn, filesystem="arrow")
+    repr(df)

--- a/dask_expr/io/tests/test_parquet.py
+++ b/dask_expr/io/tests/test_parquet.py
@@ -27,10 +27,6 @@ def parquet_file(tmpdir):
 @pytest.fixture(params=["arrow", "fsspec"])
 def filesystem(request):
     return request.param
-    if request.param == "arrow":
-        return fs.LocalFileSystem()
-    else:
-        return None  # fsspec.filesystem("file")
 
 
 def test_parquet_len(tmpdir, filesystem):
@@ -46,8 +42,8 @@ def test_parquet_len(tmpdir, filesystem):
     assert isinstance(Lengths(s.expr).optimize(), Literal)
 
 
-def test_parquet_len_filter(tmpdir):
-    df = read_parquet(_make_file(tmpdir))
+def test_parquet_len_filter(tmpdir, filesystem):
+    df = read_parquet(_make_file(tmpdir), filesystem=filesystem)
     expr = Len(df[df.c > 0].expr)
     result = expr.simplify()
     for rp in result.find_operations(ReadParquet):

--- a/dask_expr/io/tests/test_parquet.py
+++ b/dask_expr/io/tests/test_parquet.py
@@ -210,3 +210,104 @@ def test_predicate_pushdown_compound(tmpdir):
     assert {("c", ">", 20), ("b", "!=", 0)} in filters
     assert {("a", "==", 5), ("b", "!=", 0)} in filters
     assert_eq(y, z)
+
+
+import dask_expr as dd
+
+nrows = 40
+npartitions = 15
+df = pd.DataFrame(
+    {
+        "x": [i * 7 % 5 for i in range(nrows)],  # Not sorted
+        "y": [i * 2.5 for i in range(nrows)],  # Sorted
+    },
+    index=pd.Index([10 * i for i in range(nrows)], name="myindex"),
+)
+
+ddf = dd.from_pandas(df, npartitions=npartitions)
+
+
+def test_columns_index(tmpdir):
+    filesystem = fs.LocalFileSystem()
+    fn = str(tmpdir)
+    ddf.to_parquet(fn)
+
+    # With Index
+    # ----------
+    # ### Empty columns, specify index ###
+    # With divisions if supported
+    assert_eq(
+        dd.read_parquet(
+            fn,
+            columns=[],
+            index="myindex",
+            calculate_divisions=True,
+            filesystem=filesystem,
+        ),
+        ddf[[]],
+    )
+
+    # No divisions
+    assert_eq(
+        dd.read_parquet(
+            fn,
+            columns=[],
+            index="myindex",
+            calculate_divisions=False,
+            filesystem=filesystem,
+        ),
+        ddf[[]].clear_divisions(),
+        check_divisions=True,
+    )
+
+    # ### Single column, specify index ###
+    # With divisions if supported
+    assert_eq(
+        dd.read_parquet(
+            fn,
+            index="myindex",
+            columns=["x"],
+            calculate_divisions=True,
+            filesystem=filesystem,
+        ),
+        ddf[["x"]],
+    )
+
+    # No divisions
+    assert_eq(
+        dd.read_parquet(
+            fn,
+            index="myindex",
+            columns=["x"],
+            calculate_divisions=False,
+            filesystem=filesystem,
+        ),
+        ddf[["x"]].clear_divisions(),
+        check_divisions=True,
+    )
+
+    # ### Two columns, specify index ###
+    # With divisions if supported
+    assert_eq(
+        dd.read_parquet(
+            fn,
+            index="myindex",
+            columns=["x", "y"],
+            calculate_divisions=True,
+            filesystem=filesystem,
+        ),
+        ddf,
+    )
+
+    # No divisions
+    assert_eq(
+        dd.read_parquet(
+            fn,
+            index="myindex",
+            columns=["x", "y"],
+            calculate_divisions=False,
+            filesystem=filesystem,
+        ),
+        ddf.clear_divisions(),
+        check_divisions=True,
+    )


### PR DESCRIPTION
Relevant is the last commit that uses pyarrow to concat tables instead of pandas if we come from the pyarrow parquet reader. Haven't tested this thoroughly and the code probably breaks in 20 different places.

This commit seems to perform about 25% better on Q1 than main but there are too many changes and I don't know what's what. Will have to slowly walk back... 