### PR TITLE
Ensure that columns are copied in projection

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -396,6 +396,8 @@ class FrameBase(DaskMethodsMixin):
                 return self.loc[other]
         if isinstance(other, np.ndarray) or is_series_like(other):
             other = list(other)
+        elif isinstance(other, list):
+            other = other.copy()
         return new_collection(self.expr.__getitem__(other))
 
     def __bool__(self):

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -119,6 +119,13 @@ def test_info(df, verbose, buf, memory_usage):
         raise NotImplementedError(f"Case not covered for kwargs: {kwargs}")
 
 
+def test_column_projection_modify_list(df, pdf):
+    cols = ["x"]
+    result = df[cols]
+    cols.append("bla")
+    assert_eq(result, pdf[["x"]])
+
+
 def test_setitem(pdf, df):
     pdf = pdf.copy()
     pdf["z"] = pdf.x + pdf.y


### PR DESCRIPTION
closes https://github.com/dask/dask/issues/10957

This seems like a sensible thing to protect against for regular lists