### PR TITLE
Concat arrow tables before converting to pandas

### DIFF
--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -177,7 +177,7 @@ class FusedParquetIO(FusedIO):
             )
             for frag, filter in frag_filters
         )
-        table = pa.concat_tables(tables, promote_options="permissive"))
+        table = pa.concat_tables(tables, promote_options="permissive")
         return ReadParquetPyarrowFS._table_to_pandas(table, *to_pandas_args)
 
     def _task(self, index: int):

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -183,7 +183,7 @@ class FusedParquetIO(FusedIO):
             )
             for frag, filter in frag_filters
         )
-        table = pa.concat_tables(tables)
+        table = pa.concat_tables(tables, promote_options="permissive"))
         return ReadParquetPyarrowFS._table_to_pandas(table, *to_pandas_args)
 
     def _task(self, index: int):

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -5,6 +5,7 @@ import math
 import operator
 
 import numpy as np
+import pyarrow as pa
 from dask.dataframe import methods
 from dask.dataframe._pyarrow import to_pyarrow_string
 from dask.dataframe.core import apply_and_enforce, is_dataframe_like, make_meta
@@ -145,6 +146,64 @@ class FusedIO(BlockwiseIO):
 
     def _tune_up(self, parent):
         return
+
+
+class FusedParquetIO(FusedIO):
+    _parameters = ["_expr"]
+
+    @functools.cached_property
+    def _name(self):
+        return (
+            funcname(type(self.operand("_expr"))).lower()
+            + "-fused-parq-"
+            + _tokenize_deterministic(*self.operands)
+        )
+
+    @staticmethod
+    def _load_multiple_files(
+        frag_filters,
+        columns,
+        schema,
+        *to_pandas_args,
+    ):
+        from dask_expr.io.parquet import ReadParquetPyarrowFS
+
+        # Note: Ideally we'd build a pyarrow fragment that points to multiple
+        # tables since pyarrow handles IO and CPU threading separately and we're
+        # just overcomitting threads here. However, this isn't exposed at time
+        # of writing
+        # TODO: We may want to use a gloal pool with sufficient threads since
+        # executing this task in a local executor could be a little too much
+        tables = (
+            ReadParquetPyarrowFS._fragment_to_table(
+                frag,
+                filter,
+                columns,
+                schema,
+            )
+            for frag, filter in frag_filters
+        )
+        table = pa.concat_tables(tables)
+        return ReadParquetPyarrowFS._table_to_pandas(table, *to_pandas_args)
+
+    def _task(self, index: int):
+        expr = self.operand("_expr")
+        bucket = self._fusion_buckets[index]
+        fragments_filters = []
+        assert bucket
+        to_pandas_args = ()
+        for i in bucket:
+            _, frag_to_table, *to_pandas_args = expr._filtered_task(i)
+            fragments_filters.append((frag_to_table[1], frag_to_table[2]))
+            columns = frag_to_table[3]
+            schema = frag_to_table[4]
+        return (
+            self._load_multiple_files,
+            fragments_filters,
+            columns,
+            schema,
+            *to_pandas_args,
+        )
 
 
 class FromMap(PartitionsFiltered, BlockwiseIO):

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -168,12 +168,6 @@ class FusedParquetIO(FusedIO):
     ):
         from dask_expr.io.parquet import ReadParquetPyarrowFS
 
-        # Note: Ideally we'd build a pyarrow fragment that points to multiple
-        # tables since pyarrow handles IO and CPU threading separately and we're
-        # just overcomitting threads here. However, this isn't exposed at time
-        # of writing
-        # TODO: We may want to use a gloal pool with sufficient threads since
-        # executing this task in a local executor could be a little too much
         tables = (
             ReadParquetPyarrowFS._fragment_to_table(
                 frag,

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -891,9 +891,9 @@ class ReadParquetPyarrowFS(ReadParquet):
         dataset_info["dataset"] = dataset
         dataset_info["schema"] = dataset.schema
         dataset_info["base_meta"] = dataset.schema.empty_table().to_pandas()
-        self.operands[type(self)._parameters.index("_dataset_info_cache")] = (
-            dataset_info
-        )
+        self.operands[
+            type(self)._parameters.index("_dataset_info_cache")
+        ] = dataset_info
         return dataset_info
 
     @cached_property
@@ -1215,9 +1215,9 @@ class ReadParquetFSSpec(ReadParquet):
         dataset_info["all_columns"] = all_columns
         dataset_info["calculate_divisions"] = self.calculate_divisions
 
-        self.operands[type(self)._parameters.index("_dataset_info_cache")] = (
-            dataset_info
-        )
+        self.operands[
+            type(self)._parameters.index("_dataset_info_cache")
+        ] = dataset_info
         return dataset_info
 
     def _filtered_task(self, index: int):

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -58,6 +58,7 @@ from dask_expr._expr import (
 from dask_expr._reductions import Len
 from dask_expr._util import _convert_to_list, _tokenize_deterministic
 from dask_expr.io import BlockwiseIO, PartitionsFiltered
+from dask_expr.io.io import FusedParquetIO
 
 
 @normalize_token.register(pa.fs.FileInfo)
@@ -890,9 +891,9 @@ class ReadParquetPyarrowFS(ReadParquet):
         dataset_info["dataset"] = dataset
         dataset_info["schema"] = dataset.schema
         dataset_info["base_meta"] = dataset.schema.empty_table().to_pandas()
-        self.operands[
-            type(self)._parameters.index("_dataset_info_cache")
-        ] = dataset_info
+        self.operands[type(self)._parameters.index("_dataset_info_cache")] = (
+            dataset_info
+        )
         return dataset_info
 
     @cached_property
@@ -922,6 +923,13 @@ class ReadParquetPyarrowFS(ReadParquet):
 
     def _divisions(self):
         return self._division_from_stats[0]
+
+    def _tune_up(self, parent):
+        if self._fusion_compression_factor >= 1:
+            return
+        if isinstance(parent, FusedParquetIO):
+            return
+        return parent.substitute(self, FusedParquetIO(self))
 
     @cached_property
     def fragments(self):
@@ -956,19 +964,6 @@ class ReadParquetPyarrowFS(ReadParquet):
             )
         return np.array(self._dataset_info["fragments"])
 
-    def _filtered_task(self, index: int):
-        return (
-            _fragment_to_pandas,
-            FragmentWrapper(self.fragments[index]),
-            self.columns,
-            self.filters,
-            self._dataset_info["schema"].remove_metadata(),
-            self.index.name if self.index is not None else None,
-            self.arrow_to_pandas,
-            self.kwargs.get("dtype_backend"),
-            self.pyarrow_strings_enabled,
-        )
-
     @property
     def _fusion_compression_factor(self):
         if self.operand("columns") is None:
@@ -984,63 +979,86 @@ class ReadParquetPyarrowFS(ReadParquet):
 
         return max(after_projection / total_uncompressed, 0.001)
 
-
-def _fragment_to_pandas(
-    fragment_wrapper,
-    columns,
-    filters,
-    schema,
-    index_name,
-    arrow_to_pandas,
-    dtype_backend,
-    pyarrow_strings_enabled,
-):
-    fragment = fragment_wrapper.fragment
-    if isinstance(filters, list):
-        filters = pq.filters_to_expression(filters)
-    if index_name is not None and columns is not None and index_name not in columns:
-        columns = columns.copy()
-        columns.append(index_name)
-    table = fragment.to_table(
-        schema=schema,
-        columns=columns,
-        filter=filters,
-        # Batch size determines how many rows are read at once and will
-        # cause the underlying array to be split into chunks of this size
-        # (max). We'd like to avoid fragmentation as much as possible and
-        # and to set this to something like inf but we have to set a finite,
-        # positive number.
-        # In the presence of row groups, the underlying array will still be
-        # chunked per rowgroup
-        batch_size=10_000_000,
-        fragment_scan_options=pa.dataset.ParquetFragmentScanOptions(
-            pre_buffer=True,
-            cache_options=pa.CacheOptions(
-                hole_size_limit=parse_bytes("4 MiB"),
-                range_size_limit=parse_bytes("32.00 MiB"),
+    def _filtered_task(self, index: int):
+        columns = self.columns.copy()
+        index_name = self.index.name
+        if self.index is not None:
+            index_name = self.index.name
+        schema = self._dataset_info["schema"].remove_metadata()
+        if index_name:
+            if columns is None:
+                columns = list(schema.names)
+            columns.append(index_name)
+        return (
+            ReadParquetPyarrowFS._table_to_pandas,
+            (
+                ReadParquetPyarrowFS._fragment_to_table,
+                FragmentWrapper(self.fragments[index]),
+                self.filters,
+                columns,
+                schema,
             ),
-        ),
-        # TODO: Reconsider this. The OMP_NUM_THREAD variable makes it harmful to enable this
-        use_threads=True,
-    )
-    if arrow_to_pandas is None:
-        arrow_to_pandas = {}
-    else:
-        arrow_to_pandas = arrow_to_pandas.copy()
+            index_name,
+            self.arrow_to_pandas,
+            self.kwargs.get("dtype_backend"),
+            self.pyarrow_strings_enabled,
+        )
 
-    df = table.to_pandas(
-        types_mapper=_determine_type_mapper(
-            user_types_mapper=arrow_to_pandas.pop("types_mapper", None),
-            dtype_backend=dtype_backend,
-            pyarrow_strings_enabled=pyarrow_strings_enabled,
-        ),
-        use_threads=arrow_to_pandas.get("use_threads", False),
-        self_destruct=arrow_to_pandas.get("self_destruct", True),
-        **arrow_to_pandas,
-    )
-    if index_name is not None:
-        df = df.set_index(index_name)
-    return df
+    @staticmethod
+    def _fragment_to_table(fragment_wrapper, filters, columns, schema):
+        if isinstance(fragment_wrapper, FragmentWrapper):
+            fragment = fragment_wrapper.fragment
+        else:
+            fragment = fragment_wrapper
+        if isinstance(filters, list):
+            filters = pq.filters_to_expression(filters)
+        return fragment.to_table(
+            schema=schema,
+            columns=columns,
+            filter=filters,
+            # Batch size determines how many rows are read at once and will
+            # cause the underlying array to be split into chunks of this size
+            # (max). We'd like to avoid fragmentation as much as possible and
+            # and to set this to something like inf but we have to set a finite,
+            # positive number.
+            # In the presence of row groups, the underlying array will still be
+            # chunked per rowgroup
+            batch_size=10_000_000,
+            fragment_scan_options=pa.dataset.ParquetFragmentScanOptions(
+                pre_buffer=True,
+                cache_options=pa.CacheOptions(
+                    hole_size_limit=parse_bytes("4 MiB"),
+                    range_size_limit=parse_bytes("32.00 MiB"),
+                ),
+            ),
+            # TODO: Reconsider this. The OMP_NUM_THREAD variable makes it harmful to enable this
+            use_threads=True,
+        )
+
+    @staticmethod
+    def _table_to_pandas(
+        table, index_name, arrow_to_pandas, dtype_backend, pyarrow_strings_enabled
+    ):
+        if arrow_to_pandas is None:
+            arrow_to_pandas = {}
+        else:
+            arrow_to_pandas = arrow_to_pandas.copy()
+        # This can mess up index setting, etc.
+        arrow_to_pandas.pop("ignore_metadata", None)
+        df = table.to_pandas(
+            types_mapper=_determine_type_mapper(
+                user_types_mapper=arrow_to_pandas.pop("types_mapper", None),
+                dtype_backend=dtype_backend,
+                pyarrow_strings_enabled=pyarrow_strings_enabled,
+            ),
+            use_threads=arrow_to_pandas.get("use_threads", False),
+            self_destruct=arrow_to_pandas.get("self_destruct", True),
+            **arrow_to_pandas,
+            ignore_metadata=True,
+        )
+        if index_name is not None:
+            df = df.set_index(index_name)
+        return df
 
 
 class ReadParquetFSSpec(ReadParquet):
@@ -1197,9 +1215,9 @@ class ReadParquetFSSpec(ReadParquet):
         dataset_info["all_columns"] = all_columns
         dataset_info["calculate_divisions"] = self.calculate_divisions
 
-        self.operands[
-            type(self)._parameters.index("_dataset_info_cache")
-        ] = dataset_info
+        self.operands[type(self)._parameters.index("_dataset_info_cache")] = (
+            dataset_info
+        )
         return dataset_info
 
     def _filtered_task(self, index: int):


### PR DESCRIPTION
Apologies, this is building on top of https://github.com/dask-contrib/dask-expr/pull/917. I'll try to split apart

The last commit https://github.com/dask-contrib/dask-expr/commit/1e7cf9fa7c4739745b1e843bd7cb1ea069690ac4 introduces functionality that will load the individual chunks of a `FusedIO` block as arrow tables, concats those tables and only afterwards converts them to pandas.

With this I'm slowly approaching CPU saturation. The following plots show TPCH Q1 and Q6 which are both very IO heavy (6 more than 1)

Note: Those graphs also include https://github.com/dask-contrib/dask-expr/pull/917

![image](https://github.com/dask-contrib/dask-expr/assets/8629629/0d634c7c-892c-4861-89e3-4aa6b5453fdd)


and also nice network saturation

![image](https://github.com/dask-contrib/dask-expr/assets/8629629/118381b5-fffc-4263-a9f7-542238f92a93)


