### PR TITLE
Fix Copy-on-Write related bug in groupby.transform

### DIFF
--- a/dask_expr/_expr.py
+++ b/dask_expr/_expr.py
@@ -1225,6 +1225,16 @@ class ColumnsSetter(RenameFrame):
         return _rename(columns, df)
 
 
+class _DeepCopy(Elemwise):
+    _parameters = ["frame"]
+    _projection_passthrough = True
+    _filter_passthrough = True
+
+    @staticmethod
+    def operation(df):
+        return df.copy(deep=True)
+
+
 class RenameSeries(Elemwise):
     _parameters = ["frame", "index", "sorted_index"]
     _defaults = {"sorted_index": False}


### PR DESCRIPTION
pandas does a weird group key check here that becomes an issue if we consolidate during the shuffle. We already know that our group keys are not part of our original frame at this point, so we can simply clear the references and be done with it