### PR TITLE
Accept user arguments for arrow_to_pandas

### DIFF
--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -4640,6 +4640,7 @@ def read_parquet(
     parquet_file_extension=(".parq", ".parquet", ".pq"),
     filesystem="fsspec",
     engine=None,
+    arrow_to_pandas=None,
     **kwargs,
 ):
     from dask_expr.io.parquet import (
@@ -4652,6 +4653,8 @@ def read_parquet(
         path = stringify_path(path)
 
     kwargs["dtype_backend"] = dtype_backend
+    if arrow_to_pandas:
+        kwargs["arrow_to_pandas"] = arrow_to_pandas
 
     if filters is not None:
         for filter in flatten(filters, container=list):
@@ -4704,6 +4707,7 @@ def read_parquet(
                 storage_options=storage_options,
                 filesystem=filesystem,
                 ignore_metadata_file=ignore_metadata_file,
+                arrow_to_pandas=arrow_to_pandas,
                 kwargs=kwargs,
                 _series=isinstance(columns, str),
             )

--- a/dask_expr/_collection.py
+++ b/dask_expr/_collection.py
@@ -4708,6 +4708,7 @@ def read_parquet(
                 filesystem=filesystem,
                 ignore_metadata_file=ignore_metadata_file,
                 arrow_to_pandas=arrow_to_pandas,
+                pyarrow_strings_enabled=pyarrow_strings_enabled(),
                 kwargs=kwargs,
                 _series=isinstance(columns, str),
             )

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -32,6 +32,7 @@ from dask.dataframe.io.parquet.core import (
 )
 from dask.dataframe.io.parquet.utils import _split_user_options
 from dask.dataframe.io.utils import _is_local_fs
+from dask.dataframe.utils import pyarrow_strings_enabled
 from dask.delayed import delayed
 from dask.utils import apply, funcname, natural_sort_key, parse_bytes, typename
 from fsspec.utils import stringify_path
@@ -504,9 +505,7 @@ def to_parquet(
     return out
 
 
-def _determine_type_mapper(
-    *, user_types_mapper=None, dtype_backend=None, convert_string=True
-):
+def _determine_type_mapper(*, user_types_mapper, dtype_backend):
     type_mappers = []
 
     def pyarrow_type_mapper(pyarrow_dtype):
@@ -522,7 +521,7 @@ def _determine_type_mapper(
         type_mappers.append(user_types_mapper)
 
     # next in priority is converting strings
-    if convert_string:
+    if pyarrow_strings_enabled():
         type_mappers.append({pa.string(): pd.StringDtype("pyarrow")}.get)
         type_mappers.append({pa.date32(): pd.ArrowDtype(pa.date32())}.get)
         type_mappers.append({pa.date64(): pd.ArrowDtype(pa.date64())}.get)
@@ -661,6 +660,7 @@ class ReadParquetPyarrowFS(ReadParquet):
         "filesystem",
         "ignore_metadata_file",
         "calculate_divisions",
+        "arrow_to_pandas",
         "kwargs",
         "_partitions",
         "_series",
@@ -675,6 +675,7 @@ class ReadParquetPyarrowFS(ReadParquet):
         "filesystem": None,
         "ignore_metadata_file": True,
         "calculate_divisions": False,
+        "arrow_to_pandas": None,
         "kwargs": None,
         "_partitions": None,
         "_series": False,
@@ -960,6 +961,8 @@ class ReadParquetPyarrowFS(ReadParquet):
             self.filters,
             self._dataset_info["schema"].remove_metadata(),
             self.index.name if self.index is not None else None,
+            self.arrow_to_pandas,
+            self.kwargs.get("dtype_backend"),
         )
 
     @property
@@ -978,14 +981,21 @@ class ReadParquetPyarrowFS(ReadParquet):
         return max(after_projection / total_uncompressed, 0.001)
 
 
-def _fragment_to_pandas(fragment_wrapper, columns, filters, schema, index_name):
+def _fragment_to_pandas(
+    fragment_wrapper,
+    columns,
+    filters,
+    schema,
+    index_name,
+    arrow_to_pandas,
+    dtype_backend,
+):
     fragment = fragment_wrapper.fragment
     if isinstance(filters, list):
         filters = pq.filters_to_expression(filters)
     if index_name is not None and columns is not None and index_name not in columns:
         columns = columns.copy()
         columns.append(index_name)
-    # TODO: There should be a way for users to define the type mapper
     table = fragment.to_table(
         schema=schema,
         columns=columns,
@@ -1008,10 +1018,19 @@ def _fragment_to_pandas(fragment_wrapper, columns, filters, schema, index_name):
         # TODO: Reconsider this. The OMP_NUM_THREAD variable makes it harmful to enable this
         use_threads=True,
     )
+    if arrow_to_pandas is None:
+        arrow_to_pandas = {}
+    else:
+        arrow_to_pandas = arrow_to_pandas.copy()
+
     df = table.to_pandas(
-        types_mapper=_determine_type_mapper(),
-        use_threads=False,
-        self_destruct=True,
+        types_mapper=_determine_type_mapper(
+            user_types_mapper=arrow_to_pandas.pop("types_mapper", None),
+            dtype_backend=dtype_backend,
+        ),
+        use_threads=arrow_to_pandas.get("use_threads", False),
+        self_destruct=arrow_to_pandas.get("self_destruct", True),
+        **arrow_to_pandas,
     )
     if index_name is not None:
         df = df.set_index(index_name)

--- a/dask_expr/io/tests/test_parquet.py
+++ b/dask_expr/io/tests/test_parquet.py
@@ -95,6 +95,32 @@ def test_pyarrow_filesystem(parquet_file):
     assert assert_eq(df, df_pa)
 
 
+@pytest.mark.parametrize("dtype_backend", ["pyarrow", "numpy_nullable", None])
+def test_pyarrow_filesystem_dtype_backend(parquet_file, dtype_backend):
+    filesystem = fs.LocalFileSystem()
+
+    df_pa = read_parquet(
+        parquet_file, filesystem=filesystem, dtype_backend=dtype_backend
+    )
+    df = read_parquet(parquet_file, dtype_backend=dtype_backend)
+    assert assert_eq(df, df_pa)
+
+
+@pytest.mark.parametrize("types_mapper", [None, lambda x: None])
+def test_pyarrow_filesystem_types_mapper(parquet_file, types_mapper):
+    # This test isn't doing much other than ensuring the stuff is not raising
+    # anywhere
+    filesystem = fs.LocalFileSystem()
+
+    df_pa = read_parquet(
+        parquet_file,
+        filesystem=filesystem,
+        arrow_to_pandas={"types_mapper": types_mapper},
+    )
+    df = read_parquet(parquet_file, arrow_to_pandas={"types_mapper": types_mapper})
+    assert assert_eq(df, df_pa)
+
+
 def test_pyarrow_filesystem_serialize(parquet_file):
     filesystem = fs.LocalFileSystem()
 


### PR DESCRIPTION
This forwards the kwargs dtype_backend and types_mapper.

Re: types_mapper, this is a bit awkward. I'm not even sure if we need this. dask/dask has the possibility to accept a user defined type mapper. In fact, it allows passing all possible options to `arrow_to_pandas`. This is a very open approach. I implemented the same API for the new reader but I don't think many options are actually worth being piped through