### PR TITLE
Adjust automatic split_out parameter

### DIFF
--- a/dask_expr/_groupby.py
+++ b/dask_expr/_groupby.py
@@ -80,7 +80,7 @@ def _as_dict(key, value):
 
 
 def _adjust_split_out_for_group_keys(npartitions, by):
-    return math.ceil(npartitions / (100 / (len(by) - 1)))
+    return math.ceil(npartitions / (20 / (len(by) - 1)))
 
 
 class Aggregation:

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -356,12 +356,12 @@ def test_split_out_automatically():
     assert_eq(q, expected)
 
     q = df.groupby(["a", "b"]).sum()
-    assert q.optimize().npartitions == 5
+    assert q.optimize().npartitions == 25
     expected = pdf.groupby(["a", "b"]).sum()
     assert_eq(q, expected)
 
     q = df.groupby(["a", "b", "c"]).sum()
-    assert q.optimize().npartitions == 10
+    assert q.optimize().npartitions == 50
     expected = pdf.groupby(["a", "b", "c"]).sum()
     assert_eq(q, expected)
 


### PR DESCRIPTION
I tried avoiding fragmentation in the beginning, but I think we were too aggressive in squashing partitions during groupby. 

AB Test: https://github.com/coiled/benchmarks/actions/runs/8164285327

Query 10, 18 and 20 got faster (18 and 20 by a lot), everything else seems mostly noise except 13 where there might be a small slowdown, but not really noticeable.