### PR TITLE
Add _repr_html_ and prettier __repr__ w/o graph materialization

### DIFF
--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -953,7 +953,7 @@ def test_isin_repr(df):
     result = df.isin([1, 2])
     # This was raising previously
     result = result.__repr__()
-    assert "<dask_expr.expr.DataFrame: expr=Isin(frame=df, values=" in result
+    assert "Expr=Isin(frame=df, values=" in result
 
 
 def test_round(pdf):

--- a/dask_expr/tests/test_concat.py
+++ b/dask_expr/tests/test_concat.py
@@ -22,8 +22,8 @@ def df(pdf):
 
 def test_concat_str(df):
     result = str(concat([df, df], join="inner"))
-    expected = "<dask_expr.expr.DataFrame: expr=Concat(frames=[df, df], join=inner)>"
-    assert result == expected
+    expected = "Expr=Concat(frames=[df, df], join=inner)"
+    assert expected in result
 
 
 def test_concat(pdf, df):

--- a/dask_expr/tests/test_format.py
+++ b/dask_expr/tests/test_format.py
@@ -75,7 +75,7 @@ def test_to_string():
     </tr>
   </tbody>
 </table>"""  # noqa E222, E702
-    footer = f"Dask Name: frompandas, {maybe_pluralize(1, 'graph layer')}"
+    footer = f"Dask Name: frompandas, {maybe_pluralize(1, 'expression')}"
     exp = f"""<div><strong>Dask DataFrame Structure:</strong></div>
 {exp_table}
 <div>{footer}</div>"""
@@ -95,3 +95,88 @@ def test_series_format():
     H      ..."""
     )
     assert ds.to_string() == exp
+
+
+def test_series_repr():
+    s = pd.Series([1, 2, 3, 4, 5, 6, 7, 8], index=list("ABCDEFGH"))
+    ds = from_pandas(s, 3)
+
+    exp = dedent(
+        """\
+        Empty Dask Series Structure:
+        A    int64
+        D      ...
+        G      ...
+        H      ...
+        Dask Name: frompandas, 1 expression
+        Expr=df"""
+    )
+    assert repr(ds) == exp
+
+
+def test_df_repr():
+    df = pd.DataFrame({"col1": range(10), "col2": map(float, range(10))})
+    ddf = from_pandas(df, 3)
+
+    exp = dedent(
+        """\
+        Dask DataFrame Structure:
+                        col1     col2
+        npartitions=3                
+        0              int64  float64
+        4                ...      ...
+        7                ...      ...
+        9                ...      ...
+        Dask Name: frompandas, 1 expression
+        Expr=df"""
+    )
+    assert repr(ddf) == exp
+
+
+def test_df_to_html():
+    df = pd.DataFrame({"col1": range(10), "col2": map(float, range(10))})
+    ddf = from_pandas(df, 3)
+
+    exp = dedent(
+        """\
+        <div><strong>Dask DataFrame Structure:</strong></div>
+        <table border="1" class="dataframe">
+          <thead>
+            <tr style="text-align: right;">
+              <th></th>
+              <th>col1</th>
+              <th>col2</th>
+            </tr>
+            <tr>
+              <th>npartitions=3</th>
+              <th></th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>0</th>
+              <td>int64</td>
+              <td>float64</td>
+            </tr>
+            <tr>
+              <th>4</th>
+              <td>...</td>
+              <td>...</td>
+            </tr>
+            <tr>
+              <th>7</th>
+              <td>...</td>
+              <td>...</td>
+            </tr>
+            <tr>
+              <th>9</th>
+              <td>...</td>
+              <td>...</td>
+            </tr>
+          </tbody>
+        </table>
+        <div>Dask Name: frompandas, 1 expression</div>"""
+    )
+    assert ddf.to_html() == exp
+    assert ddf._repr_html_() == exp  # for jupyter


### PR DESCRIPTION
Originally part of #913, fixed by #930 which caused materialization of the graph, reverted by #941

This also updates `to_html` method which has the same issue before #930.