### PR TITLE
Change split names in task based shuffle

### DIFF
--- a/dask_expr/_shuffle.py
+++ b/dask_expr/_shuffle.py
@@ -423,7 +423,7 @@ class TaskShuffle(SimpleShuffle):
                 _filter = None
 
             shuffle_group_name = "group-" + name
-            split_name = "split-" + name
+            split_name = "split-" + name_input
 
             for global_part, part in enumerate(parts_out):
                 out = inputs[part]


### PR DESCRIPTION
cc @crusaderky 

Potential fix, but I don't know task shuffles well enough to judge if this is a bad idea